### PR TITLE
StackOverflow error in Quick Access after upgrading to eclipse 4.11

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -758,10 +758,15 @@ public abstract class QuickAccessContents {
 			@Override
 			public void controlResized(ControlEvent e) {
 				if (!showAllMatches) {
-					if (table != null && !table.isDisposed() && filterText != null && !filterText.isDisposed()
-						&& table.getShell().isVisible()) {
-						refresh(filterText.getText().toLowerCase());
-					}
+
+					// temerExec is needed to avoid StackOverflowError. See Bug 508717.
+					e.display.timerExec(100, () -> {
+						if (table != null && !table.isDisposed() && filterText != null && !filterText.isDisposed()
+								&& table.getShell().isVisible()) {
+							refresh(filterText.getText().toLowerCase());
+						}
+					});
+
 				}
 			}
 		});

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.113.0.lgc201907081100
+Bundle-Version: 3.113.0.lgc201908121600
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.ui.workbench/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.workbench</artifactId>
-  <version>3.113.0.lgc201907081100</version>
+  <version>3.113.0.lgc201908121600</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
This fixes TFS 590509
See also Eclipse Bug 508717

**Analysis:**
We removed `timerExec` from `QuickAccessContents` in https://bugs.eclipse.org/bugs/show_bug.cgi?id=495016 and RB 86332 as it caused some blinking.
Eclipse removed the patch as it caused regression - 508717.

It was suggested in Bug 495016 comment 6 to re-implement Quick Access using SWT virtual Table (SWT.VIRTUAL). But it seems like it requires refactoring. Also as Quick Access populates content based on width of popup window new implementation will still require to listen to `controlResized` events and update content accordingly. In the end, there is a chance that endless recursion will still be possible, even with virtual table.

**Solution:**
Add 100 ms delay back.