### PR TITLE
Pbi 594657 opening data type view parts which isn't included in perspective

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench;singleton:=true
-Bundle-Version: 1.9.0.lgc201811191100
+Bundle-Version: 1.9.0.lgc201909171100
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.e4.ui.workbench/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.workbench</artifactId>
-  <version>1.9.0.lgc201811191100</version>
+  <version>1.9.0.lgc201909171100</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ApplicationPartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ApplicationPartServiceImpl.java
@@ -37,7 +37,7 @@ public class ApplicationPartServiceImpl implements EPartService {
 	}
 
 	private EPartService getActiveWindowService() {
-		IEclipseContext activeWindowContext = application.getSelectedElement().getContext();// .getContext().getActiveChild();
+		IEclipseContext activeWindowContext = application.getSelectedElement().getContext();
 		if (activeWindowContext == null) {
 			throw new IllegalStateException("Application does not have an active window"); //$NON-NLS-1$
 		}

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ApplicationPartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ApplicationPartServiceImpl.java
@@ -37,7 +37,7 @@ public class ApplicationPartServiceImpl implements EPartService {
 	}
 
 	private EPartService getActiveWindowService() {
-		IEclipseContext activeWindowContext = application.getContext().getActiveChild();
+		IEclipseContext activeWindowContext = application.getSelectedElement().getContext();// .getContext().getActiveChild();
 		if (activeWindowContext == null) {
 			throw new IllegalStateException("Application does not have an active window"); //$NON-NLS-1$
 		}

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ApplicationPartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ApplicationPartServiceImpl.java
@@ -37,6 +37,7 @@ public class ApplicationPartServiceImpl implements EPartService {
 	}
 
 	private EPartService getActiveWindowService() {
+		// Eclipse bug - https://bugs.eclipse.org/bugs/show_bug.cgi?id=462610
 		IEclipseContext activeWindowContext = application.getSelectedElement().getContext();
 		if (activeWindowContext == null) {
 			throw new IllegalStateException("Application does not have an active window"); //$NON-NLS-1$

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelServiceImpl.java
@@ -677,7 +677,7 @@ public class ModelServiceImpl implements EModelService {
 		// If there is more than one placeholder then return the one in the shared area
 		for (MPlaceholder refPh : elementRefs) {
 			int loc = getElementLocation(refPh);
-			if ((loc & IN_SHARED_AREA) != 0) {
+			if ((loc & (OUTSIDE_PERSPECTIVE | IN_SHARED_AREA)) != 0) {
 				return refPh;
 			}
 		}


### PR DESCRIPTION
As a user, if my interpretation task pane view part is open, I want to be able to see my task pane even if doesn't "exist" in that perspective, so that I can make changes and continue interpreting. 

Part 1 -  https://git.openearth.community/DSGBase/vizframework/merge_requests/1889