### PR TITLE
Bug 586023:Correlation Toolbar changing/disappearing

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DetachedDropAgent.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DetachedDropAgent.java
@@ -14,11 +14,14 @@
 
 package org.eclipse.e4.ui.workbench.addons.dndaddon;
 
+import java.util.List;
+import org.eclipse.e4.ui.model.application.ui.MElementContainer;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPlaceholder;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainerElement;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
+import org.eclipse.e4.ui.model.application.ui.basic.MStackElement;
 import org.eclipse.e4.ui.workbench.IPresentationEngine;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.SWT;
@@ -64,7 +67,16 @@ public class DetachedDropAgent extends DropAgent {
 		}
 
 		Rectangle rectangle = getRectangle(dragElement, info);
-
+		MElementContainer<MUIElement> parent = dragElement.getParent();
+		if (parent.getSelectedElement() == dragElement && dragElement instanceof MStackElement) {
+			MUIElement stackElement = dragElement;
+			// avoid activation of any sibling
+			List<MUIElement> children = dragElement.getParent().getChildren();
+			if (children.size() > 1) {
+				children.stream().filter(c -> c != stackElement && c.isToBeRendered() && c.isVisible()).findAny()
+						.ifPresent(c -> dndManager.getModelService().bringToTop(c));
+			}
+		}
 		modelService.detach((MPartSashContainerElement) dragElement, rectangle.x, rectangle.y, rectangle.width,
 				rectangle.height);
 

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DetachedDropAgent.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DetachedDropAgent.java
@@ -14,14 +14,11 @@
 
 package org.eclipse.e4.ui.workbench.addons.dndaddon;
 
-import java.util.List;
-import org.eclipse.e4.ui.model.application.ui.MElementContainer;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPlaceholder;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainerElement;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
-import org.eclipse.e4.ui.model.application.ui.basic.MStackElement;
 import org.eclipse.e4.ui.workbench.IPresentationEngine;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.SWT;
@@ -67,16 +64,6 @@ public class DetachedDropAgent extends DropAgent {
 		}
 
 		Rectangle rectangle = getRectangle(dragElement, info);
-		MElementContainer<MUIElement> parent = dragElement.getParent();
-		if (parent.getSelectedElement() == dragElement && dragElement instanceof MStackElement) {
-			MUIElement stackElement = dragElement;
-			// avoid activation of any sibling
-			List<MUIElement> children = dragElement.getParent().getChildren();
-			if (children.size() > 1) {
-				children.stream().filter(c -> c != stackElement && c.isToBeRendered() && c.isVisible()).findAny()
-						.ifPresent(c -> dndManager.getModelService().bringToTop(c));
-			}
-		}
 		modelService.detach((MPartSashContainerElement) dragElement, rectangle.x, rectangle.y, rectangle.width,
 				rectangle.height);
 

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DetachedDropAgent.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DetachedDropAgent.java
@@ -64,11 +64,9 @@ public class DetachedDropAgent extends DropAgent {
 		}
 
 		Rectangle rectangle = getRectangle(dragElement, info);
+
 		modelService.detach((MPartSashContainerElement) dragElement, rectangle.x, rectangle.y, rectangle.width,
 				rectangle.height);
-
-		// Fully re-activate the part since its location has changed
-		reactivatePart(dragElement);
 
 		return true;
 	}

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/PartDragAgent.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/PartDragAgent.java
@@ -104,10 +104,11 @@ public class PartDragAgent extends DragAgent {
 
 	@Override
 	public void dragFinished(boolean performDrop, DnDInfo info) {
+		super.dragFinished(performDrop, info);
 		if (dragElement instanceof MPart) {
 			EPartService ps = dndManager.getDragWindow().getContext().get(EPartService.class);
+			if (ps.getActivePart() != dragElement)
 			ps.activate((MPart) dragElement);
 		}
-		super.dragFinished(performDrop, info);
 	}
 }

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/SplitDropAgent2.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/SplitDropAgent2.java
@@ -305,6 +305,7 @@ public class SplitDropAgent2 extends DropAgent {
 								.filter(c -> c != dragElement && c.isToBeRendered() && c.isVisible()).findAny()
 								.orElse(null));
 				if (sibling != null) {
+					parent.setSelectedElement(null);
 					modelService.bringToTop(sibling);
 				}
 			}
@@ -341,9 +342,6 @@ public class SplitDropAgent2 extends DropAgent {
 			}
 		}
 		modelService.insert(toInsert, (MPartSashContainerElement) relToElement, where, ratio);
-		if (!draggedStack) {
-			reactivatePart(dragElement);
-		}
 		return true;
 	}
 

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/SplitDropAgent2.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/SplitDropAgent2.java
@@ -14,6 +14,7 @@
 package org.eclipse.e4.ui.workbench.addons.dndaddon;
 
 import java.util.List;
+import org.eclipse.e4.ui.model.application.ui.MElementContainer;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
 import org.eclipse.e4.ui.model.application.ui.advanced.MArea;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
@@ -277,8 +278,6 @@ public class SplitDropAgent2 extends DropAgent {
 		clearFeedback();
 		relToElement = null;
 
-		reactivatePart(dragElement);
-
 		super.dragLeave(dragElement, info);
 	}
 
@@ -295,6 +294,15 @@ public class SplitDropAgent2 extends DropAgent {
 		} else {
 			// wrap it in a stack if it's a part
 			MStackElement stackElement = (MStackElement) dragElement;
+			MElementContainer<MUIElement> parent = stackElement.getParent();
+			if (parent.getSelectedElement() == stackElement) {
+				// avoid activation of any sibling
+				List<MUIElement> children = dragElement.getParent().getChildren();
+				if (children.size() > 1) {
+					children.stream().filter(c -> c != dragElement && c.isToBeRendered() && c.isVisible()).findAny()
+							.ifPresent(c -> dndManager.getModelService().bringToTop(c));
+				}
+			}
 			MPartStack newStack = BasicFactoryImpl.eINSTANCE.createPartStack();
 			newStack.getChildren().add(stackElement);
 			newStack.setSelectedElement(stackElement);
@@ -327,11 +335,7 @@ public class SplitDropAgent2 extends DropAgent {
 				relToElement = persp.getChildren().get(0);
 			}
 		}
-
-		dndManager.getModelService().insert(toInsert, (MPartSashContainerElement) relToElement,
-				where, ratio);
-		// reactivatePart(dragElement);
-
+		dndManager.getModelService().insert(toInsert, (MPartSashContainerElement) relToElement, where, ratio);
 		return true;
 	}
 

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/StackDropAgent.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/StackDropAgent.java
@@ -375,6 +375,7 @@ public class StackDropAgent extends DropAgent {
 				}
 				children.remove(dragElement);
 				if (switchedWindows) {
+					dropWin.getParent().setSelectedElement(dropWin);
 					/**
 					 * find a part to activate in the prior window, preferably:
 					 * <ol>

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/StackDropAgent.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/StackDropAgent.java
@@ -364,8 +364,14 @@ public class StackDropAgent extends DropAgent {
 			if (parent != null) {
 				List<MUIElement> children = parent.getChildren();
 				if (!switchedWindows && children.size() > 1) {
-					children.stream().filter(c -> c != dragElement && c.isToBeRendered() && c.isVisible()).findAny()
-							.ifPresent(c -> ms.bringToTop(c));
+					MUIElement sibling = children.stream()
+							.filter(c -> c != dragElement && c.getTags().contains("activeEditor")).findAny(). //$NON-NLS-1$
+							orElseGet(() -> children.stream()
+									.filter(c -> c != dragElement && c.isToBeRendered() && c.isVisible()).findAny()
+									.orElse(null));
+					if (sibling != null) {
+						ms.bringToTop(sibling);
+					}
 				}
 				children.remove(dragElement);
 				if (switchedWindows) {

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.14.500.lgc201907171000
+Bundle-Version: 0.14.500.lgc201911221000
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/pom.xml
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.workbench.renderers.swt</artifactId>
-  <version>0.14.500.lgc201907171000</version>
+  <version>0.14.500.lgc201911221000</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
@@ -27,6 +27,7 @@ import org.eclipse.e4.ui.internal.workbench.swt.Policy;
 import org.eclipse.e4.ui.internal.workbench.swt.WorkbenchSWTActivator;
 import org.eclipse.e4.ui.model.application.ui.MContext;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
+import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.model.application.ui.menu.ItemType;
 import org.eclipse.e4.ui.model.application.ui.menu.MItem;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenu;
@@ -510,11 +511,14 @@ public abstract class AbstractContributionItem extends ContributionItem {
 
 	private ISafeRunnable getUpdateRunner() {
 		if (updateRunner == null) {
+		    final MWindow window = modelService.getTopLevelWindowFor(getModel());
 			updateRunner = new ISafeRunnable() {
 				@Override
 				public void run() throws Exception {
 					boolean shouldEnable = canExecuteItem(null);
-					if (shouldEnable != modelItem.isEnabled()) {
+					final boolean ourWindow = window.getParent().getSelectedElement() == window;
+					// omit updating enabled state when contribution item window is not active
+					if (ourWindow && shouldEnable != modelItem.isEnabled()) {
 						modelItem.setEnabled(shouldEnable);
 						update();
 					}

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolBarContributionRecord.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolBarContributionRecord.java
@@ -64,6 +64,8 @@ public class ToolBarContributionRecord {
 	}
 
 	public void updateVisibility(IEclipseContext context) {
+		MWindow tbWindow = renderer.modelService.getTopLevelWindowFor(toolbarModel);
+		boolean ourWindow = tbWindow.getParent().getSelectedElement() == tbWindow;
 		ExpressionContext exprContext = new ExpressionContext(context);
 		updateIsVisible(exprContext);
 		HashSet<ToolBarContributionRecord> recentlyUpdated = new HashSet<>();
@@ -72,7 +74,7 @@ public class ToolBarContributionRecord {
 		for (MToolBarElement item : generatedElements) {
 			boolean currentVisibility = computeVisibility(recentlyUpdated,
 					item, exprContext);
-			if (item.isVisible() != currentVisibility) {
+			if (ourWindow && item.isVisible() != currentVisibility) {
 				item.setVisible(currentVisibility);
 				changed = true;
 			}
@@ -80,7 +82,7 @@ public class ToolBarContributionRecord {
 		for (MToolBarElement item : sharedElements) {
 			boolean currentVisibility = computeVisibility(recentlyUpdated,
 					item, exprContext);
-			if (item.isVisible() != currentVisibility) {
+			if (ourWindow && item.isVisible() != currentVisibility) {
 				item.setVisible(currentVisibility);
 				changed = true;
 			}

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelServiceImpl.java
@@ -430,15 +430,6 @@ public class ModelServiceImpl implements EModelService {
 		return elementsList;
 	}
 
-	private <T> Iterable<T> findPerspectiveElements(MUIElement searchRoot, String id,
-			Class<T> clazz,
-			List<String> tagsToMatch) {
-		LinkedHashSet<T> elements = new LinkedHashSet<>();
-		ElementMatcher matcher = new ElementMatcher(id, clazz, tagsToMatch);
-		findElementsRecursive(searchRoot, clazz, matcher, elements, PRESENTATION);
-		return elements;
-	}
-
 	@Override
 	public MUIElement find(String id, MUIElement searchRoot) {
 		if (id == null || id.length() == 0) {
@@ -658,24 +649,19 @@ public class ModelServiceImpl implements EModelService {
 
 	@Override
 	public MPlaceholder findPlaceholderFor(MWindow window, MUIElement element) {
-		Iterable<MPlaceholder> phList = findPerspectiveElements(window, null, MPlaceholder.class, null);
-		List<MPlaceholder> elementRefs = new ArrayList<>();
-		for (MPlaceholder ph : phList) {
-			if (ph.getRef() == element) {
-				elementRefs.add(ph);
-			}
-		}
-
-		if (elementRefs.isEmpty()) {
+		LinkedHashSet<MPlaceholder> elements = new LinkedHashSet<>();
+		findElementsRecursive(window, MPlaceholder.class, ph -> ((MPlaceholder) ph).getRef() == element, elements,
+				PRESENTATION);
+		if (elements.isEmpty()) {
 			return null;
 		}
 
-		if (elementRefs.size() == 1) {
-			return elementRefs.get(0);
+		if (elements.size() == 1) {
+			return elements.iterator().next();
 		}
 
 		// If there is more than one placeholder then return the one in the shared area
-		for (MPlaceholder refPh : elementRefs) {
+		for (MPlaceholder refPh : elements) {
 			int loc = getElementLocation(refPh);
 			if ((loc & (OUTSIDE_PERSPECTIVE | IN_SHARED_AREA)) != 0) {
 				return refPh;
@@ -683,7 +669,7 @@ public class ModelServiceImpl implements EModelService {
 		}
 
 		// Just return the first one
-		return elementRefs.get(0);
+		return elements.iterator().next();
 	}
 
 	@Override

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartActivationHistory.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartActivationHistory.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.MElementContainer;
@@ -260,6 +259,13 @@ class PartActivationHistory {
 	}
 
 	MPart getNextActivationCandidate(Collection<MPart> validParts, MPart part) {
+		if (part.getCurSharedRef() != null) {
+			MPart candidate = validParts.stream().filter(c -> c != part && c.getTags().contains("activeEditor")) //$NON-NLS-1$
+					.findAny().orElse(null);
+			if (candidate != null) {
+				return candidate;
+			}
+		}
 		MArea area = isInArea(part);
 		if (area != null) {
 			// focus should stay in the area if possible

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/services/EvaluationReference.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/services/EvaluationReference.java
@@ -102,18 +102,19 @@ public class EvaluationReference extends RunAndTrack implements IEvaluationRefer
 		if (!postingChanges) {
 			return;
 		}
-		if (!hasRun) {
-			getListener().propertyChange(
-					new PropertyChangeEvent(this, getProperty(), null, Boolean.valueOf(cache)));
-		} else if (!participating) {
-			getListener().propertyChange(
-					new PropertyChangeEvent(this, getProperty(), Boolean.valueOf(value), null));
-		}
-		if (value != cache) {
-			getListener().propertyChange(
-					new PropertyChangeEvent(this, getProperty(), Boolean.valueOf(value), Boolean
-							.valueOf(cache)));
-		}
+		runExternalCode(() -> {
+			if (!hasRun) {
+				getListener()
+						.propertyChange(new PropertyChangeEvent(this, getProperty(), null, Boolean.valueOf(cache)));
+			} else if (!participating) {
+				getListener()
+						.propertyChange(new PropertyChangeEvent(this, getProperty(), Boolean.valueOf(value), null));
+			}
+			if (value != cache) {
+				getListener().propertyChange(
+						new PropertyChangeEvent(this, getProperty(), Boolean.valueOf(value), Boolean.valueOf(cache)));
+			}
+		});
 		hasRun = true;
 	}
 


### PR DESCRIPTION
Omit setting toolbar visible state for items not in active window.  This eliminates distracting changes and competing activity in inactive windows from the active window.
execute EvaluationReference PropertyChangeEvent within runExternalCode. www.eclipse.org/forums/index.php/t/1102033/

avoid activating parts as a side-effect of tiling or DnD of parts.