### PR TITLE
Fix ImageDescriptor to support desired size of SVG resource

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.15.100.lgc202002141800
+Bundle-Version: 3.15.100.lgc202002271800
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.jface/pom.xml
+++ b/bundles/org.eclipse.jface/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jface</groupId>
   <artifactId>org.eclipse.jface</artifactId>
-  <version>3.15.100.lgc202002141800</version>
+  <version>3.15.100.lgc202002271800</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
@@ -204,15 +204,15 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor {
 			if (urlSpec.endsWith(PNG_EXT)) {
 				String svgUrlSpec = urlSpec.replace(PNG_EXT, SVG_EXT);
 
-				try {
-					// find size suffix and remove it
-					for (String sfx : IMG_SFXS) {
-						if (svgUrlSpec.contains(sfx)) {
-							svgUrlSpec = svgUrlSpec.replace(sfx, ""); //$NON-NLS-1$
-							break;
-						}
+				// find size suffix and remove it
+				for (String sfx : IMG_SFXS) {
+					if (svgUrlSpec.contains(sfx)) {
+						svgUrlSpec = svgUrlSpec.replace(sfx, ""); //$NON-NLS-1$
+						break;
 					}
+				}
 
+				try {
 					new URL(svgUrlSpec).openConnection().connect();
 					urlSpec = svgUrlSpec;
 
@@ -260,10 +260,9 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor {
 		}
 
 		Point size = new Point(SvgImageDescriptor.DEFAULT_SIZE.x, SvgImageDescriptor.DEFAULT_SIZE.y);
-		String[] params = urlQuery.split("&"); //$NON-NLS-1$
 		final String widthSeq = "width="; //$NON-NLS-1$
 		final String heightSeq = "height="; //$NON-NLS-1$
-		for (String parameter : params) {
+		for (String parameter : urlQuery.split("&")) { //$NON-NLS-1$
 			if (parameter.contains(widthSeq)) {
 				size.x = Integer.parseInt(parameter.replace(widthSeq, "")); //$NON-NLS-1$
 			} else if (parameter.contains(heightSeq)) {
@@ -279,11 +278,11 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor {
 	private static final boolean SHOW_MISSING_SVG_IMAGES = Boolean.getBoolean("svg.show.missing"); //$NON-NLS-1$
 
 	// the method will be removed once we will have all SVG assets
+	// old SVG resources have suffix _32
 	private static String getOldSvgUrl(String svgUrlSpec) {
 		try {
 			int dotIndex = svgUrlSpec.lastIndexOf(SVG_EXT);
 			if (dotIndex != -1) {
-				// old SVG resources have suffix _32
 				String oldSvgName = svgUrlSpec.substring(0, dotIndex) + "_32.svg"; //$NON-NLS-1$
 				new URL(oldSvgName).openConnection().connect();
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.PaletteData;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
 
@@ -168,11 +169,6 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor {
         return new ImageDataImageDescriptor(img);
     }
 
-	// Debug code, will be removed
-	private static final boolean USE_SVG_IMAGES = Boolean.getBoolean("svg.enable"); //$NON-NLS-1$
-	private static final boolean USE_OLD_SVG_IMAGES = Boolean.getBoolean("svg.old_32.enable"); //$NON-NLS-1$
-	private static final boolean SHOW_MISSING_SVG_IMAGES = Boolean.getBoolean("svg.show.missing"); //$NON-NLS-1$
-
     /**
      * Creates and returns a new image descriptor from a URL.
      *
@@ -184,67 +180,53 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor {
 			return getMissingImageDescriptor();
 		}
 
-		String urlSpec = url.toString();
+		ImageDescriptor svgImageDescriptor = getSvgImageDescriptor(url);
 
+		return svgImageDescriptor != null ? svgImageDescriptor : new URLImageDescriptor(url);
+	}
+
+	private static final String SVG_EXT = ".svg"; //$NON-NLS-1$
+	private static final String PNG_EXT = ".png"; //$NON-NLS-1$
+	private static final String[] IMG_SFXS = new String[] { "_16", "_24", "_32", "_8", "_10", "_48" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+
+	private static ImageDescriptor getSvgImageDescriptor(URL url) {
 		if (USE_SVG_IMAGES && url.getPath().contains("lgc")) { //$NON-NLS-1$
+			Point size = SvgImageDescriptor.DEFAULT_SIZE;
 
-			int width = 16;
-			int height = 16;
+			String urlSpec = url.toString();
 
-			// get size parameters from query
-			// SVG image can be loaded in desired size using query,
-			// example: platform:/path/toSvg/image.svg?width=100&height=40
-			// if dimensions are missing then default 16x16 will be used
 			String query = url.getQuery();
 			if (query != null) {
-				String[] params = query.split("&"); //$NON-NLS-1$
-				final String widthSeq = "width="; //$NON-NLS-1$
-				final String heightSeq = "height="; //$NON-NLS-1$
-				for (String parameter : params) {
-					if (parameter.contains(widthSeq)) {
-						width = Integer.parseInt(parameter.replace(widthSeq, "")); //$NON-NLS-1$
-					} else if (parameter.contains(heightSeq)) {
-						height = Integer.parseInt(parameter.replace(heightSeq, "")); //$NON-NLS-1$
-					}
-				}
-
+				size = getCustomSizeFromQuery(query);
 				urlSpec = urlSpec.replace("?" + query, ""); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 
-			if (urlSpec.endsWith(".png")) { //$NON-NLS-1$
-				URL svgUrl = null;
-				String svgUrlSpec = ""; //$NON-NLS-1$
-				try {
-					svgUrlSpec = urlSpec.replace(".png", ".svg") //$NON-NLS-1$ //$NON-NLS-2$
-							.replace("_16", "").replace("_24", "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-							.replace("_32", "").replace("_10", "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-							.replace("_8", ""); //$NON-NLS-1$ //$NON-NLS-2$
-					svgUrl = new URL(svgUrlSpec);
-					svgUrl.openConnection().connect();
+			if (urlSpec.endsWith(PNG_EXT)) {
+				String svgUrlSpec = urlSpec.replace(PNG_EXT, SVG_EXT);
 
+				try {
+					// find size suffix and remove it
+					for (String sfx : IMG_SFXS) {
+						if (svgUrlSpec.contains(sfx)) {
+							svgUrlSpec = svgUrlSpec.replace(sfx, ""); //$NON-NLS-1$
+							break;
+						}
+					}
+
+					new URL(svgUrlSpec).openConnection().connect();
 					urlSpec = svgUrlSpec;
 
 				} catch (IOException e) {
-					// old SVG resources have suffix _32
 					if (USE_OLD_SVG_IMAGES) {
-						try {
-							int dotIndex = svgUrlSpec.lastIndexOf(".svg"); //$NON-NLS-1$
-							if (dotIndex != -1) {
-								String oldSvgName = svgUrlSpec.substring(0, dotIndex) + "_32.svg"; //$NON-NLS-1$
-								svgUrl = new URL(oldSvgName);
-								svgUrl.openConnection().connect();
-
-								urlSpec = oldSvgName;
-							}
-						} catch (IOException e1) {
-						}
+						String oldSvgUrlSpec = getOldSvgUrl(svgUrlSpec);
+						urlSpec = oldSvgUrlSpec != null ? oldSvgUrlSpec : urlSpec;
 					}
 				}
 			}
 
-			if (urlSpec.endsWith(".svg")) { //$NON-NLS-1$
+			if (urlSpec.endsWith(SVG_EXT)) {
 				try {
-					return new SvgImageDescriptor(new URL(urlSpec), width, height);
+					return new SvgImageDescriptor(new URL(urlSpec), size);
 				} catch (MalformedURLException e) {
 					return getMissingImageDescriptor();
 				}
@@ -254,8 +236,62 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor {
 				return getMissingImageDescriptor();
 			}
 		}
+		return null;
+	}
 
-		return new URLImageDescriptor(url);
+	/**
+	 * Get size parameters from query. SVG image can be loaded in desired size using
+	 * query, example:
+	 * <p>
+	 * {@code platform:/path/toSvg/image.svg?width=100&height=40}<br>
+	 * {@code platform:/path/toSvg/image.svg?size=48}
+	 * <p>
+	 * If dimensions are missing then default
+	 * {@link SvgImageDescriptor#DEFAULT_SIZE} will be used
+	 *
+	 * @param urlQuery {@link URL#getQuery()}
+	 * @return Point that contains size values
+	 */
+	private static Point getCustomSizeFromQuery(String urlQuery) {
+		final String sizeSeq = "size="; //$NON-NLS-1$
+		if (urlQuery.contains(sizeSeq)) {
+			int parsedSize = Integer.parseInt(urlQuery.replace(sizeSeq, "")); //$NON-NLS-1$
+			return new Point(parsedSize, parsedSize);
+		}
+
+		Point size = new Point(SvgImageDescriptor.DEFAULT_SIZE.x, SvgImageDescriptor.DEFAULT_SIZE.y);
+		String[] params = urlQuery.split("&"); //$NON-NLS-1$
+		final String widthSeq = "width="; //$NON-NLS-1$
+		final String heightSeq = "height="; //$NON-NLS-1$
+		for (String parameter : params) {
+			if (parameter.contains(widthSeq)) {
+				size.x = Integer.parseInt(parameter.replace(widthSeq, "")); //$NON-NLS-1$
+			} else if (parameter.contains(heightSeq)) {
+				size.y = Integer.parseInt(parameter.replace(heightSeq, "")); //$NON-NLS-1$
+			}
+		}
+		return size;
+	}
+
+	// Debug code, will be removed
+	private static final boolean USE_SVG_IMAGES = Boolean.getBoolean("svg.enable"); //$NON-NLS-1$
+	private static final boolean USE_OLD_SVG_IMAGES = Boolean.getBoolean("svg.old_32.enable"); //$NON-NLS-1$
+	private static final boolean SHOW_MISSING_SVG_IMAGES = Boolean.getBoolean("svg.show.missing"); //$NON-NLS-1$
+
+	// the method will be removed once we will have all SVG assets
+	private static String getOldSvgUrl(String svgUrlSpec) {
+		try {
+			int dotIndex = svgUrlSpec.lastIndexOf(SVG_EXT);
+			if (dotIndex != -1) {
+				// old SVG resources have suffix _32
+				String oldSvgName = svgUrlSpec.substring(0, dotIndex) + "_32.svg"; //$NON-NLS-1$
+				new URL(oldSvgName).openConnection().connect();
+
+				return oldSvgName;
+			}
+		} catch (IOException e1) {
+		}
+		return null;
 	}
 
     @Override

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
@@ -10,7 +10,6 @@ import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.internal.image.SVGFileFormat;
 import org.eclipse.swt.internal.image.SVGHelper;
 
 /**
@@ -23,8 +22,14 @@ public class SvgImageDescriptor extends ImageDescriptor {
 	private int renderWidth;
 	private int renderHeight;
 
-	/** Default size of image descriptor */
-	public static final Point DEFAULT_SIZE = new Point(16, 16);
+	@SuppressWarnings("boxing")
+	private static final int SIZE_PROPERTY = Integer.getInteger("svg.image.size.default", 16); //$NON-NLS-1$
+
+	/**
+	 * Default size of image descriptor. Can be configurable using system property
+	 * {@code svg.image.size.default}
+	 */
+	public static final Point DEFAULT_SIZE = new Point(SIZE_PROPERTY, SIZE_PROPERTY);
 
 	/**
 	 * @param url
@@ -60,7 +65,7 @@ public class SvgImageDescriptor extends ImageDescriptor {
 			byte[] imageBytes = SVGHelper.loadSvg(url, renderWidth * scale, renderHeight * scale);
 			return new ImageData(new ByteArrayInputStream(imageBytes));
 		} catch (Exception e) {
-			Logger.getLogger(SVGFileFormat.class.getName()).severe("SVG EXCEPTION: " + url.getFile() + " " + e); //$NON-NLS-1$ //$NON-NLS-2$
+			Logger.getLogger(SvgImageDescriptor.class.getName()).severe("SVG EXCEPTION: " + url.getFile() + " " + e); //$NON-NLS-1$ //$NON-NLS-2$
 			return new ImageData(DEFAULT_SIZE.x, DEFAULT_SIZE.y, 24, new PaletteData());
 		}
     }
@@ -76,5 +81,4 @@ public class SvgImageDescriptor extends ImageDescriptor {
 	public URL getURL() {
 		return url;
 	}
-
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
@@ -1,12 +1,17 @@
 package org.eclipse.jface.resource;
 
+import java.io.ByteArrayInputStream;
 import java.net.URL;
+import java.util.logging.Logger;
 
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
+import org.eclipse.swt.graphics.PaletteData;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.internal.image.SVGFileFormat;
+import org.eclipse.swt.internal.image.SVGHelper;
 
 /**
  * @since 3.4
@@ -18,12 +23,23 @@ public class SvgImageDescriptor extends ImageDescriptor {
 	private int renderWidth;
 	private int renderHeight;
 
+	/** Default size of image descriptor */
+	public static final Point DEFAULT_SIZE = new Point(16, 16);
+
 	/**
 	 * @param url
 	 * @param renderSize
 	 */
     public SvgImageDescriptor(URL url, int renderSize) {
 		this(url, renderSize, renderSize);
+	}
+
+	/**
+	 * @param url
+	 * @param size
+	 */
+	public SvgImageDescriptor(URL url, Point size) {
+		this(url, size.x, size.y);
 	}
 
 	/**
@@ -40,7 +56,13 @@ public class SvgImageDescriptor extends ImageDescriptor {
     @Override
     public ImageData getImageData(int zoom) {
 		int scale = zoom / 100;
-		return SVGFileFormat.loadImageData(url, renderWidth * scale, renderHeight * scale);
+		try {
+			byte[] imageBytes = SVGHelper.loadSvg(url, renderWidth * scale, renderHeight * scale);
+			return new ImageData(new ByteArrayInputStream(imageBytes));
+		} catch (Exception e) {
+			Logger.getLogger(SVGFileFormat.class.getName()).severe("SVG EXCEPTION: " + url.getFile() + " " + e); //$NON-NLS-1$ //$NON-NLS-2$
+			return new ImageData(DEFAULT_SIZE.x, DEFAULT_SIZE.y, 24, new PaletteData());
+		}
     }
 
     @Override

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
@@ -15,20 +15,32 @@ import org.eclipse.swt.internal.image.SVGFileFormat;
 public class SvgImageDescriptor extends ImageDescriptor {
 
     private URL url;
-    private int renderSize;
+	private int renderWidth;
+	private int renderHeight;
 
 	/**
 	 * @param url
 	 * @param renderSize
 	 */
     public SvgImageDescriptor(URL url, int renderSize) {
+		this(url, renderSize, renderSize);
+	}
+
+	/**
+	 * @param url
+	 * @param width
+	 * @param height
+	 */
+	public SvgImageDescriptor(URL url, int width, int height) {
         this.url = url;
-        this.renderSize = renderSize;
+		this.renderWidth = width;
+		this.renderHeight = height;
     }
 
     @Override
     public ImageData getImageData(int zoom) {
-        return SVGFileFormat.loadImageData(url, renderSize * zoom / 100);
+		int scale = zoom / 100;
+		return SVGFileFormat.loadImageData(url, renderWidth * scale, renderHeight * scale);
     }
 
     @Override


### PR DESCRIPTION
Current version of ImageDescriptor loads icons only (size 16). In this case it is impossible to load Image with other sizes (123 x 124 for example). We need to provide current mechanizm.
With these changes we can load resource using URL
platform:/plugin/com.lgc.icons/com/lgc/icons/CommonButton/btn_default_light.svg?width=123&height=124

Additional utils will be provided in DSG code.
Additional PR: https://github.com/Halliburton-Landmark/eclipse.platform.swt/pull/7