### PR TITLE
TFS 670992 clear event queue prior to enabling/disabling shells

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressManager.java
@@ -966,7 +966,6 @@ public class ProgressManager extends ProgressProvider implements IProgressServic
 			dialog.run(fork, cancelable, runnable);
 			return;
 		}
-
 		busyCursorWhile(runnable);
 	}
 
@@ -1030,6 +1029,8 @@ public class ProgressManager extends ProgressProvider implements IProgressServic
 	private void setUserInterfaceActive(boolean active) {
 		IWorkbench workbench = PlatformUI.getWorkbench();
 		Shell[] shells = workbench.getDisplay().getShells();
+		while (workbench.getDisplay().readAndDispatch())
+			// clear event queue before enabling;
 		if (active) {
 			for (int i = 0; i < shells.length; i++) {
 				if (!shells[i].isDisposed()) {

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.113.0.lgc202004271300
+Bundle-Version: 3.113.0.lgc202005291300
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.ui.workbench/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.workbench</artifactId>
-  <version>3.113.0.lgc202004271300</version>
+  <version>3.113.0.lgc202005291300</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
when loading seismic or horizon data (e.g. from panning a Map) multiple progress monitors are used in quick succession.  It appears that events overlap.