### PR TITLE
check for minimized tag before firePartHidden

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPage.java
@@ -894,7 +894,11 @@ public class WorkbenchPage implements IWorkbenchPage {
 		} else if (UIEvents.isREMOVE(event)) {
 			if (UIEvents.contains(event, UIEvents.EventTags.OLD_VALUE,
 					org.eclipse.e4.ui.workbench.addons.minmax.TrimStack.MINIMIZED_AND_SHOWING)) {
-				firePartHidden(thePart);
+				MPlaceholder ph = thePart.getCurSharedRef();
+				MUIElement parent = ph == null ? thePart.getParent() : ph.getParent();
+				if (parent.getTags().contains(IPresentationEngine.MINIMIZED)) {
+					firePartHidden(thePart);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
MINIMIZED_AND_SHOWING removal handler should check that the part stack contains the MINIMIZED tag prior to firing part hidden event.  Otherwise, when a part is restored from MINIMIZED__AND_SHOWING state a partHidden event may be fired.