### PR TITLE
PART 2 - Exception when exiting from App with no editors

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.14.500.lgc202006211000
+Bundle-Version: 0.14.500.lgc202007071000
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/pom.xml
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.workbench.renderers.swt</artifactId>
-  <version>0.14.500.lgc202006211000</version>
+  <version>0.14.500.lgc202007071000</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ContributedPartRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ContributedPartRenderer.java
@@ -272,7 +272,9 @@ public class ContributedPartRenderer extends SWTPartRenderer {
 				parent.setRedraw(false);
 				super.disposeWidget(element);
 			} finally {
-				parent.setRedraw(true);
+				if (!parent.isDisposed()) {
+					parent.setRedraw(true);
+				}
 			}
 		} else {
 			super.disposeWidget(element);


### PR DESCRIPTION
**Problem:** Exception when exiting from App with no editors. Parent get disposed due to event queue clearing in BrowserPanel.handleEvent. while(Display.getDefault().readAndDispatch()).


**Solution:** Add check for widget is disposed.


Part 1 - https://github.com/Halliburton-Landmark/eclipse.platform.swt/pull/15