### PR TITLE
Bug670992 Floating toolbar icons are disabled after adding Seismic and clicking Show All icon

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressManager.java
@@ -1029,9 +1029,6 @@ public class ProgressManager extends ProgressProvider implements IProgressServic
 	private void setUserInterfaceActive(boolean active) {
 		IWorkbench workbench = PlatformUI.getWorkbench();
 		Shell[] shells = workbench.getDisplay().getShells();
-		while (workbench.getDisplay().readAndDispatch()) {
-			// clear event queue before enabling
-		}
 		if (active) {
 			for (int i = 0; i < shells.length; i++) {
 				if (!shells[i].isDisposed()) {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressManager.java
@@ -1029,8 +1029,9 @@ public class ProgressManager extends ProgressProvider implements IProgressServic
 	private void setUserInterfaceActive(boolean active) {
 		IWorkbench workbench = PlatformUI.getWorkbench();
 		Shell[] shells = workbench.getDisplay().getShells();
-		while (workbench.getDisplay().readAndDispatch())
-			// clear event queue before enabling;
+		while (workbench.getDisplay().readAndDispatch()) {
+			// clear event queue before enabling
+		}
 		if (active) {
 			for (int i = 0; i < shells.length; i++) {
 				if (!shells[i].isDisposed()) {

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.113.0.lgc202006181318
+Bundle-Version: 3.113.0.lgc202007070700
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.ui.workbench/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.workbench</artifactId>
-  <version>3.113.0.lgc202006181318</version>
+  <version>3.113.0.lgc202007070700</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
clear event queue in ProgressManager prior to enabling/disabling shells

redo of faulty MR https://github.com/Halliburton-Landmark/eclipse.platform.ui/pull/22