### PR TITLE
fix hadnles leak

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.15.100.lgc202006261800
+Bundle-Version: 3.15.100.lgc202007311800
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.jface/pom.xml
+++ b/bundles/org.eclipse.jface/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jface</groupId>
   <artifactId>org.eclipse.jface</artifactId>
-  <version>3.15.100.lgc202006261800</version>
+  <version>3.15.100.lgc202007311800</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
@@ -197,4 +197,36 @@ public class SvgImageDescriptor extends ImageDescriptor {
 		}
 		return null;
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + renderHeight;
+		result = prime * result + renderWidth;
+		result = prime * result + ((url == null) ? 0 : url.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SvgImageDescriptor other = (SvgImageDescriptor) obj;
+		if (renderHeight != other.renderHeight)
+			return false;
+		if (renderWidth != other.renderWidth)
+			return false;
+		if (url == null) {
+			if (other.url != null)
+				return false;
+		} else if (!url.equals(other.url))
+			return false;
+		return true;
+	}
+
 }


### PR DESCRIPTION
**Problem:** SWT no more handles exception

**Analysis:** image descriptor cache is map based and fails if hashcode is not implemented

**Solution:** implement hashcode or SvgImageDescriptor to enable caching SVG images and reduce SWT handle usage

@mastanarao