### PR TITLE
Bug 703924 use active workbench window when ISources value fails

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/handlers/HandlerUtil.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/handlers/HandlerUtil.java
@@ -247,11 +247,16 @@ public class HandlerUtil {
 	 */
 	public static IEditorPart getActiveEditorChecked(ExecutionEvent event)
 			throws ExecutionException {
-		Object o = getVariableChecked(event, ISources.ACTIVE_EDITOR_NAME);
-		if (o == null) {
+		Object o = null;
+		try {
+			o = getVariableChecked(event, ISources.ACTIVE_EDITOR_NAME);
+		} catch (ExecutionException ee) {
 			IWorkbenchWindow ww = getActiveWorkbenchWindow(event);
 			if (ww != null) {
 				o = ww.getActivePage().getActiveEditor();
+			}
+			if (o == null) {
+				throw ee;
 			}
 		}
 		if (!(o instanceof IEditorPart)) {
@@ -288,11 +293,16 @@ public class HandlerUtil {
 	 */
 	public static String getActiveEditorIdChecked(ExecutionEvent event)
 			throws ExecutionException {
-		Object o = getVariableChecked(event, ISources.ACTIVE_EDITOR_ID_NAME);
-		if (o == null) {
+		Object o = null;
+		try {
+			o = getVariableChecked(event, ISources.ACTIVE_EDITOR_ID_NAME);
+		} catch (ExecutionException ee) {
 			IEditorPart e = getActiveEditor(event);
 			if (e != null) {
 				o = e.getEditorSite().getId();
+			}
+			if (o == null) {
+				throw ee;
 			}
 		}
 		if (!(o instanceof String)) {
@@ -331,11 +341,16 @@ public class HandlerUtil {
 	 */
 	public static IEditorInput getActiveEditorInputChecked(ExecutionEvent event)
 			throws ExecutionException {
-		Object o = getVariableChecked(event, ISources.ACTIVE_EDITOR_INPUT_NAME);
-		if (o == null) {
+		Object o = null;
+		try {
+			o = getVariableChecked(event, ISources.ACTIVE_EDITOR_INPUT_NAME);
+		} catch (ExecutionException ee) {
 			IEditorPart e = getActiveEditor(event);
 			if (e != null) {
 				o = e.getEditorInput();
+			}
+			if (o == null) {
+				throw ee;
 			}
 		}
 		if (!(o instanceof IEditorInput)) {
@@ -371,11 +386,16 @@ public class HandlerUtil {
 	 */
 	public static IWorkbenchPart getActivePartChecked(ExecutionEvent event)
 			throws ExecutionException {
-		Object o = getVariableChecked(event, ISources.ACTIVE_PART_NAME);
-		if (o == null) {
+		Object o = null;
+		try {
+			o = getVariableChecked(event, ISources.ACTIVE_PART_NAME);
+		} catch (ExecutionException ee) {
 			IWorkbenchWindow ww = getActiveWorkbenchWindow(event);
 			if (ww != null) {
 				o = ww.getActivePage().getActivePart();
+			}
+			if (o == null) {
+				throw ee;
 			}
 		}
 		if (!(o instanceof IWorkbenchPart)) {
@@ -411,11 +431,16 @@ public class HandlerUtil {
 	 */
 	public static String getActivePartIdChecked(ExecutionEvent event)
 			throws ExecutionException {
-		Object o = getVariableChecked(event, ISources.ACTIVE_PART_ID_NAME);
-		if (o == null) {
+		Object o = null;
+		try {
+			o = getVariableChecked(event, ISources.ACTIVE_PART_ID_NAME);
+		} catch (ExecutionException ee) {
 			IWorkbenchPart p = getActivePart(event);
 			if (p != null) {
 				o = p.getSite().getId();
+			}
+			if (o == null) {
+				throw ee;
 			}
 		}
 		if (!(o instanceof String)) {
@@ -451,11 +476,16 @@ public class HandlerUtil {
 	 */
 	public static IWorkbenchSite getActiveSiteChecked(ExecutionEvent event)
 			throws ExecutionException {
-		Object o = getVariableChecked(event, ISources.ACTIVE_SITE_NAME);
-		if (o == null) {
+		Object o = null;
+		try {
+			o = getVariableChecked(event, ISources.ACTIVE_SITE_NAME);
+		} catch (ExecutionException ee) {
 			IWorkbenchPart p = getActivePart(event);
 			if (p != null) {
 				o = p.getSite();
+			}
+			if (o == null) {
+				throw ee;
 			}
 		}
 		if (!(o instanceof IWorkbenchSite)) {

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.113.0.lgc202007241000
+Bundle-Version: 3.113.0.lgc202008100800
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.ui.workbench/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.workbench</artifactId>
-  <version>3.113.0.lgc202007241000</version>
+  <version>3.113.0.lgc202008100800</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
When used from outside a workbench window context HandlerUtil is not reliable, e.g. a Dialog.

With the prior EvaluationService version it would work for getActiveEditor, since ACTIVE_EDITOR_NAME was not included in the EvaluationService filter, but not for other ISources values methods, e.g. getActivePart or getActiveEditorId in which case it would fail. see https://www.eclipse.org/forums/index.php?t=msg&th=1089140 

ISources.ACTIVE_EDITOR_NAME was added to the filter to make the EvaluationService work more reliably for core expression evaulation.  Excluding ACTIVE_EDITOR_NAME puts the ISources in an inconsistent state, e.g. ACTIVE_EDITOR_NAME might return a Cube, but ACTIVE_EDITOR_ID_NAME might be for a Map, since it is filtered out.

Otherwise, ISources values are set by WorkbenchPage.  Unfortunately, when a Dialog has focus its context is active and this context does not contain any of the ISources values which makes HandlerUtil fail.

To make HandlerUtil work outside of workbench window we use the active workbench window when the ISources value fails.
