### PR TITLE
remove fast return for part activating

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench;singleton:=true
-Bundle-Version: 1.9.0.lgc202006181318
+Bundle-Version: 1.9.0.lgc202009041318
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.e4.ui.workbench/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.workbench</artifactId>
-  <version>1.9.0.lgc202006181318</version>
+  <version>1.9.0.lgc202009041318</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
@@ -696,9 +696,6 @@ public class PartServiceImpl implements EPartService {
 			activePart = part;
 			return;
 		}
-		if (partActivating == part) { // avoid recursive activations. (e.g. from focusGui)
-			return;
-		}
 		if (Policy.DEBUG_FOCUS) {
 			Activator.trace(Policy.DEBUG_FOCUS_FLAG, "Activating " + part, null);//$NON-NLS-1$
 		}

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
@@ -696,8 +696,7 @@ public class PartServiceImpl implements EPartService {
 			activePart = part;
 			return;
 		}
-		if (partActivating == part) { // avoid recursive activations. (e.g. from focusGui)
-			modelService.bringToTop(part);
+		if (partActivating != null) { // avoid recursive activations. (e.g. from focusGui)
 			return;
 		}
 		if (Policy.DEBUG_FOCUS) {

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
@@ -696,7 +696,7 @@ public class PartServiceImpl implements EPartService {
 			activePart = part;
 			return;
 		}
-		if (partActivating != null) { // avoid recursive activations. (e.g. from focusGui)
+		if (partActivating != null) { // avoid recursive activations. (e.g. from focusGui or bringToTop)
 			return;
 		}
 		if (Policy.DEBUG_FOCUS) {

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
@@ -696,6 +696,10 @@ public class PartServiceImpl implements EPartService {
 			activePart = part;
 			return;
 		}
+		if (partActivating == part) { // avoid recursive activations. (e.g. from focusGui)
+			modelService.bringToTop(part);
+			return;
+		}
 		if (Policy.DEBUG_FOCUS) {
 			Activator.trace(Policy.DEBUG_FOCUS_FLAG, "Activating " + part, null);//$NON-NLS-1$
 		}


### PR DESCRIPTION
fix for tfs#712789

regression from https://github.com/Halliburton-Landmark/eclipse.platform.ui/pull/23/commits/162ace8954f8a8ef8de25ded9c8641dcc0457b84

with this changes Window - Show View - Colorbar not always brings on top.

@hb91546 @mmaria
