### PR TITLE
Bug1135883 Throttler StackOverflow

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/util/Throttler.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/util/Throttler.java
@@ -56,6 +56,7 @@ public class Throttler {
 		int minWaitBetweenRunMillis = (int) minWaitTime.toMillis();
 		Runnable runner = () -> {
 			scheduled.set(false);
+			lastRunNanos = System.nanoTime();
 			runnable.run();
 			lastRunNanos = System.nanoTime();
 		};


### PR DESCRIPTION
stackoverflow random error while exiting DSG in  com.lgc.dsp-pres/com.lgc.dsp.ui.pres.editor.toolbar.DSToolBarContributionManager 

![image](https://github.com/Halliburton-Landmark/eclipse.platform.ui/assets/2519865/2b9e31e9-ed56-433f-b51a-c46031a9e1be)

In this change we update _lastRunNanos_ to prevent Throttler _timerExec_ from running immediately avoiding the recursion.