### PR TITLE
Revert custom styling, replace CTabRendering with Eclipse's source

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.css.swt;singleton:=true
-Bundle-Version: 0.14.800.lgc20230509-1200
+Bundle-Version: 0.14.800.lgc20231124-1600
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/custom/CSSPropertyUnselectedTabsSWTHandler.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/custom/CSSPropertyUnselectedTabsSWTHandler.java
@@ -27,13 +27,14 @@ import org.eclipse.swt.widgets.Listener;
 import org.w3c.dom.css.CSSValue;
 
 public class CSSPropertyUnselectedTabsSWTHandler extends AbstractCSSPropertySWTHandler {
+	private static final String UNSELECTED_TABS_COLOR_PROP = "swt-unselected-tabs-color";
 
 	private static final String RESIZE_LISTENER = "CSSPropertyUnselectedTabsSWTHandler.resizeListener";
 
 	@Override
 	protected void applyCSSProperty(Control control, String property,
 			CSSValue value, String pseudo, CSSEngine engine) throws Exception {
-		if (!(control instanceof CTabFolder)) {
+		if (!(control instanceof CTabFolder) || !isUnselectedTabsColorProp(property)) {
 			return;
 		}
 		CTabFolder folder = ((CTabFolder) control);
@@ -75,6 +76,10 @@ public class CSSPropertyUnselectedTabsSWTHandler extends AbstractCSSPropertySWTH
 			String pseudo, CSSEngine engine) throws Exception {
 		// TODO Auto-generated method stub
 		return null;
+	}
+
+	private boolean isUnselectedTabsColorProp(String property) {
+		return UNSELECTED_TABS_COLOR_PROP.equals(property);
 	}
 
 	// TODO: It needs to be refactored when the Bug 33276 gets fixed

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/internal/css/swt/ICTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/internal/css/swt/ICTabRendering.java
@@ -23,23 +23,13 @@ public interface ICTabRendering {
 
 	void setSelectedTabHighlight(Color color);
 
-	void setFillToolbarArea(boolean fillToolbarArea);
-
-	void setSelectedHoverBorderColor(Color color);
-
 	void setSelectedTabFill(Color color);
 
 	void setSelectedTabFill(Color[] colors, int[] percents);
 
-	void setUnselectedHoverBorderColor(Color color);
-
-	void setUnselectedHoverColor(Color color);
-
 	void setUnselectedTabsColor(Color color);
 
 	void setUnselectedTabsColor(Color[] colors, int[] percents);
-
-	void setUnselectedTabOutline(Color color);
 
 	void setUnselectedHotTabsColorBackground(Color color);
 
@@ -69,6 +59,4 @@ public interface ICTabRendering {
 	 * @param drawCustomTabContentBackground
 	 */
 	void setDrawCustomTabContentBackground(boolean drawCustomTabContentBackground);
-
-	void setWrappedTabFolderColor(Color color);
 }

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.15.800.lgc20230509-1200
+Bundle-Version: 0.15.800.lgc20231124-1600
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -18,9 +18,7 @@
 package org.eclipse.e4.ui.workbench.renderers.swt;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Objects;
-import javax.inject.Inject;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
@@ -38,13 +36,9 @@ import org.eclipse.swt.graphics.Pattern;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.ToolBar;
 
 @SuppressWarnings("restriction")
 public class CTabRendering extends CTabFolderRenderer implements ICTabRendering, IPreferenceChangeListener {
-	private static final String CONTAINS_TOOLBAR = "CTabRendering.containsToolbar"; //$NON-NLS-1$
 
 	/**
 	 * A named preference for setting CTabFolder's to be rendered with rounded
@@ -62,16 +56,33 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	public static final boolean USE_ROUND_TABS_DEFAULT = false;
 
 	// Constants for circle drawing
-	final static int LEFT_TOP = 0;
-	final static int LEFT_BOTTOM = 1;
-	final static int RIGHT_TOP = 2;
-	final static int RIGHT_BOTTOM = 3;
+	static enum CirclePart {
+		LEFT_TOP, LEFT_BOTTOM, RIGHT_TOP, RIGHT_BOTTOM;
+
+		static CirclePart left(boolean onBottom) {
+			if (onBottom) {
+				return LEFT_BOTTOM;
+			}
+			return LEFT_TOP;
+		}
+
+		static CirclePart right(boolean onBottom) {
+			if (onBottom) {
+				return RIGHT_BOTTOM;
+			}
+			return RIGHT_TOP;
+		}
+
+		public boolean isLeft() {
+			return this == LEFT_TOP || this == LEFT_BOTTOM;
+		}
+
+		public boolean isTop() {
+			return this == LEFT_TOP || this == RIGHT_TOP;
+		}
+	}
 
 	static final int SQUARE_CORNER = 0;
-
-	// drop shadow constants
-	final static int SIDE_DROP_WIDTH = 3;
-	final static int BOTTOM_DROP_WIDTH = 4;
 
 	// keylines
 	static final int OUTER_KEYLINE_WIDTH = 1;
@@ -95,7 +106,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 
 	Image toolbarActiveImage, toolbarInactiveImage;
 
-	int cornerSize = 10;
+	int cornerSize = 0;
 
 	Color outerKeylineColor, innerKeylineColor;
 	boolean active;
@@ -108,33 +119,20 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 
 	Color tabOutlineColor;
 
-	Color unselectedTabOutlineColor;
-
 	int paddingLeft = 0, paddingRight = 0, paddingTop = 0, paddingBottom = 0;
 
-	private final CTabFolderRendererWrapper rendererWrapper;
-	private final CTabFolderWrapper parentWrapper;
+	private CTabFolderWrapper parentWrapper;
 
-	private Color unselectedHoverColor;
+	private Color hotUnselectedTabsColorBackground;
 	private Color selectedTabHighlightColor;
 	private boolean drawTabHighlightOnTop = true;
 
 
 	private boolean drawCustomTabContentBackground;
 
-	private Color selectedHoverBorderColor;
-
-	private Color unselectedHoverBorderColor;
-
-	private Color wrappedTabFolderColor;
-
-	private boolean fillToolbarArea = true;
-
-	@Inject
 	public CTabRendering(CTabFolder parent) {
 		super(parent);
 		parentWrapper = new CTabFolderWrapper(parent);
-		rendererWrapper = new CTabFolderRendererWrapper(this);
 
 		IEclipsePreferences preferences = getSwtRendererPreferences();
 		preferences.addPreferenceChangeListener(this);
@@ -144,33 +142,8 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	}
 
 	@Override
-	public void setUnselectedHoverColor(Color newColor) {
-		this.unselectedHoverColor = newColor;
-	}
-
-	@Override
-	public void setUnselectedHoverBorderColor(Color newColor) {
-		this.unselectedHoverBorderColor = newColor;
-	}
-
-	@Override
-	public void setSelectedHoverBorderColor(Color newColor) {
-		this.selectedHoverBorderColor = newColor;
-	}
-
-	@Override
-	public void setWrappedTabFolderColor(Color newColor) {
-		this.wrappedTabFolderColor = newColor;
-	}
-
-	@Override
-	public void setFillToolbarArea(boolean fillToolbarArea) {
-		this.fillToolbarArea = fillToolbarArea;
-	}
-
-	@Override
 	public void setUnselectedHotTabsColorBackground(Color color) {
-		this.unselectedHoverColor = color;
+		this.hotUnselectedTabsColorBackground = color;
 	}
 
 	@Override
@@ -188,7 +161,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		case PART_BODY:
 			if (state == SWT.FILL) {
 				x = -1 - paddingLeft;
-				int tabHeight = parent.getTabHeight();
+				int tabHeight = parent.getTabHeight() + 1;
 				y = onBottom ? y - paddingTop - marginHeight - borderTop - TAB_OUTLINE_WIDTH
 						: y - paddingTop - marginHeight - tabHeight - borderTop - TAB_OUTLINE_WIDTH;
 				width = 2 + paddingLeft + paddingRight;
@@ -197,11 +170,20 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			} else {
 				x = x - marginWidth - OUTER_KEYLINE_WIDTH - INNER_KEYLINE_WIDTH - sideDropWidth;
 				width = width + 2 * OUTER_KEYLINE_WIDTH + 2 * INNER_KEYLINE_WIDTH + 2 * marginWidth + 2 * sideDropWidth;
-				int tabHeight = parent.getTabHeight();
+				int tabHeight = parent.getTabHeight() + 1; // TODO: Figure out
+				// what
+				// to do about the
+				// +1
+				// TODO: Fix
 				if (parent.getMinimized()) {
 					y = onBottom ? y - borderTop - 5 : y - tabHeight - borderTop - 5;
 					height = borderTop + borderBottom + tabHeight;
 				} else {
+					// y = tabFolder.onBottom ? y - marginHeight -
+					// highlight_margin
+					// - borderTop: y - marginHeight - highlight_header -
+					// tabHeight
+					// - borderTop;
 					y = onBottom ? y - marginHeight - borderTop
 							: y - marginHeight - tabHeight - borderTop - TAB_OUTLINE_WIDTH;
 					height = height + borderBottom + borderTop + 2 * marginHeight + tabHeight + TAB_OUTLINE_WIDTH;
@@ -215,15 +197,15 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		case PART_BORDER:
 			x = x - INNER_KEYLINE_WIDTH - OUTER_KEYLINE_WIDTH - sideDropWidth - ITEM_LEFT_MARGIN;
 			width = width + 2 * (INNER_KEYLINE_WIDTH + OUTER_KEYLINE_WIDTH + sideDropWidth) + ITEM_RIGHT_MARGIN;
-			height = height + borderTop + borderBottom;
-			y = y - borderTop;
+			height += borderTop + borderBottom;
+			y -= borderTop;
 			break;
 		default:
 			if (0 <= part && part < parent.getItemCount()) {
-				x = x - ITEM_LEFT_MARGIN;// - (CORNER_SIZE/2);
-				width = width + ITEM_LEFT_MARGIN + ITEM_RIGHT_MARGIN + 1;
-				y = y - ITEM_TOP_MARGIN;
-				height = height + ITEM_TOP_MARGIN + ITEM_BOTTOM_MARGIN;
+				x -= ITEM_LEFT_MARGIN;// - (CORNER_SIZE/2);
+				width += ITEM_LEFT_MARGIN + ITEM_RIGHT_MARGIN + 1;
+				y -= ITEM_TOP_MARGIN;
+				height += ITEM_TOP_MARGIN + ITEM_BOTTOM_MARGIN;
 			}
 			break;
 		}
@@ -253,10 +235,13 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			}
 			return;
 		case PART_BODY:
-			this.drawTabBody(gc, bounds, state);
+			this.drawTabBody(gc, bounds);
 			return;
 		case PART_HEADER:
 			this.drawTabHeader(gc, bounds, state);
+			if (cornerSize != SQUARE_CORNER) {
+				this.drawCorners(gc, bounds);
+			}
 			return;
 		default:
 			if (0 <= part && part < parent.getItemCount()) {
@@ -264,11 +249,10 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 				// Resetting it before draw the tabs prevents draw issues.
 				gc.setClipping((Rectangle) null);
 				gc.setAdvanced(true);
-				if (bounds.width == 0 || bounds.height == 0) {
+				if (bounds.width == 0 || bounds.height == 0)
 					return;
-				}
 				if ((state & SWT.SELECTED) != 0) {
-					drawSelectedTab(part, gc, bounds, state);
+					drawSelectedTab(part, gc, bounds);
 					state &= ~SWT.BACKGROUND;
 					super.draw(part, state, bounds, gc);
 				} else {
@@ -287,6 +271,45 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			}
 		}
 		super.draw(part, state, bounds, gc);
+	}
+
+	void drawCorners(GC gc, Rectangle bounds) {
+		Color bg = gc.getBackground();
+		Color fg = gc.getForeground();
+		Color toFill = parent.getParent().getBackground();
+		gc.setAlpha(255);
+		gc.setBackground(toFill);
+		gc.setForeground(toFill);
+		int radius = cornerSize / 2 + 1;
+		int leftX = bounds.x - 1;
+		int topY = bounds.y - 1;
+		int rightX = bounds.x + bounds.width;
+		int bottomY = bounds.y + bounds.height;
+		drawCutout(gc, leftX, topY, radius, CirclePart.LEFT_TOP);
+		drawCutout(gc, rightX, topY, radius, CirclePart.RIGHT_TOP);
+		drawCutout(gc, leftX, bottomY, radius, CirclePart.LEFT_BOTTOM);
+		drawCutout(gc, rightX, bottomY, radius, CirclePart.RIGHT_BOTTOM);
+		gc.setBackground(bg);
+		gc.setForeground(fg);
+	}
+
+	private void drawCutout(GC gc, int x, int y, int radius, CirclePart side) {
+		int centerX = x + (side.isLeft() ? radius : -radius);
+		int centerY = y + (side.isTop() ? radius : -radius);
+
+		int[] circle = drawCircle(centerX, centerY, radius, side);
+		int[] result = new int[circle.length + 2];
+		result[0] = x;
+		result[1] = y;
+		int count = circle.length / 2;
+		for (int idx = 0; idx < count; idx++) {
+			int destIdx = idx * 2 + 2;
+			int srcIdx = (count - 1 - idx) * 2;
+			result[destIdx] = circle[srcIdx];
+			result[destIdx + 1] = circle[srcIdx + 1];
+		}
+
+		gc.fillPolygon(result);
 	}
 
 	void drawTabHeader(GC gc, Rectangle bounds, int state) {
@@ -315,7 +338,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		}
 	}
 
-	void drawTabBody(GC gc, Rectangle bounds, int state) {
+	void drawTabBody(GC gc, Rectangle bounds) {
 		int marginWidth = parent.marginWidth;
 		int marginHeight = parent.marginHeight;
 		int delta = INNER_KEYLINE_WIDTH + OUTER_KEYLINE_WIDTH + 2 * marginWidth;
@@ -338,20 +361,20 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			int circY = bounds.y + radius;
 
 			// Body
-			int[] ltt = drawCircle(circX, circY, radius, LEFT_TOP);
+			int[] ltt = drawCircle(circX, circY, radius, CirclePart.LEFT_TOP);
 			System.arraycopy(ltt, 0, points, index, ltt.length);
 			index += ltt.length;
 
-			int[] lbb = drawCircle(circX, circY + height - (radius * 2), radius, LEFT_BOTTOM);
+			int[] lbb = drawCircle(circX, circY + height - (radius * 2), radius, CirclePart.LEFT_BOTTOM);
 			System.arraycopy(lbb, 0, points, index, lbb.length);
 			index += lbb.length;
 
 			int[] rb = drawCircle(circX + width - (radius * 2), circY + height - (radius * 2), radius,
-					RIGHT_BOTTOM);
+					CirclePart.RIGHT_BOTTOM);
 			System.arraycopy(rb, 0, points, index, rb.length);
 			index += rb.length;
 
-			int[] rt = drawCircle(circX + width - (radius * 2), circY, radius, RIGHT_TOP);
+			int[] rt = drawCircle(circX + width - (radius * 2), circY, radius, CirclePart.RIGHT_TOP);
 			System.arraycopy(rt, 0, points, index, rt.length);
 			index += rt.length;
 			points[index++] = circX;
@@ -420,14 +443,13 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		int index = 0;
 		int radius = cornerSize / 2;
 		int circX = bounds.x + radius;
-		int selectionX1, selectionY1, selectionX2, selectionY2;
-		int circY = onBottom ? bounds.y + bounds.height - 1 - header - radius : bounds.y + radius;
+		int circY = onBottom ? bounds.y + bounds.height + 1 - header - radius : bounds.y - 1 + radius;
 		if (itemIndex == 0 && bounds.x == -computeTrim(CTabFolderRenderer.PART_HEADER, SWT.NONE, 0, 0, 0, 0).x) {
 			circX -= 1;
-			points[index++] = circX - radius + 1;
+			points[index++] = circX - radius;
 			points[index++] = bottomY;
 
-			points[index++] = selectionX1 = circX + 1 - radius;
+			points[index++] = circX - radius;
 			points[index++] = bottomY;
 		} else {
 			if (active) {
@@ -438,50 +460,21 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			points[index++] = bottomY;
 		}
 
-		int startX = -1, endX = -1;
+		int[] ltt = drawCircle(circX, circY, radius, CirclePart.left(onBottom));
 		if (!onBottom) {
-			int[] ltt = drawCircle(circX + 1, circY, radius, LEFT_TOP);
-			startX = ltt[6];
-			for (int i = 0; i < ltt.length / 2; i += 2) {
-				int tmp = ltt[i];
-				ltt[i] = ltt[ltt.length - i - 2];
-				ltt[ltt.length - i - 2] = tmp;
-				tmp = ltt[i + 1];
-				ltt[i + 1] = ltt[ltt.length - i - 1];
-				ltt[ltt.length - i - 1] = tmp;
-			}
-			System.arraycopy(ltt, 0, points, index, ltt.length);
-			index += ltt.length;
-
-			int[] rt = drawCircle(circX + width - (radius * 2), circY, radius, RIGHT_TOP);
-			endX = rt[rt.length - 4];
-			for (int i = 0; i < rt.length / 2; i += 2) {
-				int tmp = rt[i];
-				rt[i] = rt[rt.length - i - 2];
-				rt[rt.length - i - 2] = tmp;
-				tmp = rt[i + 1];
-				rt[i + 1] = rt[rt.length - i - 1];
-				rt[rt.length - i - 1] = tmp;
-			}
-			System.arraycopy(rt, 0, points, index, rt.length);
-			index += rt.length;
-
-			points[index++] = selectionX2 = bounds.width + circX - radius;
-			points[index++] = selectionY2 = bounds.y + bounds.height;
-		} else {
-			int[] ltt = drawCircle(circX + 1, circY, radius, LEFT_BOTTOM);
-			startX = ltt[6];
-			System.arraycopy(ltt, 0, points, index, ltt.length);
-			index += ltt.length;
-
-			int[] rt = drawCircle(circX + width - (radius * 2), circY, radius, RIGHT_BOTTOM);
-			endX = rt[rt.length - 4];
-			System.arraycopy(rt, 0, points, index, rt.length);
-			index += rt.length;
-
-			points[index++] = selectionX2 = bounds.width + circX - radius;
-			points[index++] = selectionY2 = bottomY;
+			mirrorCirclePoints(ltt);
 		}
+		System.arraycopy(ltt, 0, points, index, ltt.length);
+		index += ltt.length;
+		int[] rt = drawCircle(circX + width - (radius * 2), circY, radius, CirclePart.right(onBottom));
+		if (!onBottom) {
+			mirrorCirclePoints(rt);
+		}
+		System.arraycopy(rt, 0, points, index, rt.length);
+		index += rt.length;
+
+		points[index++] = bounds.width + circX - radius;
+		points[index++] = bottomY;
 
 		if (active) {
 			points[index++] = parentSize.x + INNER_KEYLINE_WIDTH + OUTER_KEYLINE_WIDTH;
@@ -493,7 +486,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		return tmpPoints;
 	}
 
-	void drawSelectedTab(int itemIndex, GC gc, Rectangle bounds, int state) {
+	void drawSelectedTab(int itemIndex, GC gc, Rectangle bounds) {
 		if (parent.getSingle() && parent.getItem(itemIndex).isShowing())
 			return;
 
@@ -555,28 +548,20 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		}
 
 		gc.drawLine(selectionX1, selectionY1, selectionX2, selectionY2);
-		if (tabOutlineColor == null) {
+
+		if (tabOutlineColor == null)
 			tabOutlineColor = gc.getDevice().getSystemColor(SWT.COLOR_BLACK);
-		}
 		gc.setForeground(tabOutlineColor);
 
 		Color gradientLineTop = null;
 		Pattern foregroundPattern = null;
 		if (!active && !onBottom) {
-			gradientLineTop = getGradientLineTop(gc);
+			RGB blendColor = gc.getDevice().getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW).getRGB();
+			RGB topGradient = blend(blendColor, tabOutlineColor.getRGB(), 40);
+			gradientLineTop = new Color(gc.getDevice(), topGradient);
 			foregroundPattern = new Pattern(gc.getDevice(), 0, 0, 0, bounds.height + 1, gradientLineTop,
 					gc.getDevice().getSystemColor(SWT.COLOR_WHITE));
 			gc.setForegroundPattern(foregroundPattern);
-		}
-		if ((state & SWT.HOT) != 0) {
-			if (selectedHoverBorderColor == null) {
-				gradientLineTop = getGradientLineTop(gc);
-				foregroundPattern = new Pattern(gc.getDevice(), 0, 0, 0, bounds.height + 1, gradientLineTop,
-						gc.getDevice().getSystemColor(SWT.COLOR_WHITE));
-				gc.setForegroundPattern(foregroundPattern);
-			} else {
-				gc.setForeground(selectedHoverBorderColor);
-			}
 		}
 
 		gc.setClipping((Rectangle) null);
@@ -620,152 +605,135 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	}
 
 	void drawUnselectedTab(int itemIndex, GC gc, Rectangle bounds, int state) {
-		int header = 0;
-		int width = bounds.width;
-		boolean onBottom = parent.getTabPosition() == SWT.BOTTOM;
-		int[] points = new int[1024];
-		int[] inactive = new int[8];
-		int index = 0, inactive_index = 0;
-		int radius = cornerSize / 2;
-		int circX = bounds.x + radius;
-		int circY = onBottom ? bounds.y + bounds.height - 1 - header - radius : bounds.y + 1 + radius;
-		int bottomY = onBottom ? bounds.y - header : bounds.y + bounds.height;
-
-		int leftIndex = circX;
-		if (itemIndex == 0) {
-			points[index++] = leftIndex - radius + 1;
-			points[index++] = bottomY;
-		} else {
-			points[index++] = bounds.x + 1;
-			points[index++] = bottomY;
-		}
-
-		if (!active) {
-			System.arraycopy(points, 0, inactive, 0, index);
-			inactive_index += 2;
-		}
-
-		int rightIndex = circX - 1;
-		if (!onBottom) {
-			int[] ltt = drawCircle(leftIndex + 1, circY, radius, LEFT_TOP);
-			for (int i = 0; i < ltt.length / 2; i += 2) {
-				int tmp = ltt[i];
-				ltt[i] = ltt[ltt.length - i - 2];
-				ltt[ltt.length - i - 2] = tmp;
-				tmp = ltt[i + 1];
-				ltt[i + 1] = ltt[ltt.length - i - 1];
-				ltt[ltt.length - i - 1] = tmp;
-			}
-			System.arraycopy(ltt, 0, points, index, ltt.length);
-			index += ltt.length;
-
-			if (!active) {
-				System.arraycopy(ltt, 0, inactive, inactive_index, 2);
-				inactive_index += 2;
-			}
-
-			int[] rt = drawCircle(rightIndex + width - (radius * 2), circY, radius, RIGHT_TOP);
-			for (int i = 0; i < rt.length / 2; i += 2) {
-				int tmp = rt[i];
-				rt[i] = rt[rt.length - i - 2];
-				rt[rt.length - i - 2] = tmp;
-				tmp = rt[i + 1];
-				rt[i + 1] = rt[rt.length - i - 1];
-				rt[rt.length - i - 1] = tmp;
-			}
-			System.arraycopy(rt, 0, points, index, rt.length);
-			index += rt.length;
-			if (!active) {
-				System.arraycopy(rt, rt.length - 4, inactive, inactive_index, 2);
-				inactive[inactive_index] -= 1;
-				inactive_index += 2;
-			}
-		} else {
-			int[] ltt = drawCircle(leftIndex + 1, circY, radius, LEFT_BOTTOM);
-			System.arraycopy(ltt, 0, points, index, ltt.length);
-			index += ltt.length;
-
-			if (!active) {
-				System.arraycopy(ltt, 0, inactive, inactive_index, 2);
-				inactive_index += 2;
-			}
-
-			int[] rt = drawCircle(rightIndex + width - (radius * 2), circY, radius, RIGHT_BOTTOM);
-			System.arraycopy(rt, 0, points, index, rt.length);
-			index += rt.length;
-			if (!active) {
-				System.arraycopy(rt, rt.length - 4, inactive, inactive_index, 2);
-				inactive[inactive_index] -= 1;
-				inactive_index += 2;
-			}
-
-		}
-
-		points[index++] = bounds.width + rightIndex - radius;
-		points[index++] = bottomY;
-
-		if (!active) {
-			System.arraycopy(points, index - 2, inactive, inactive_index, 2);
-			inactive[inactive_index] -= 1;
-			inactive_index += 2;
-		}
-		gc.setClipping(points[0], onBottom ? bounds.y - header : bounds.y,
-				parent.getSize().x - (0 + INNER_KEYLINE_WIDTH + OUTER_KEYLINE_WIDTH), bounds.y + bounds.height);
-		Color color = unselectedHoverColor;
-		if (color == null) {
-			// Fallback: if color was not set, use white for highlighting
-			// hot tab. }
-			color = gc.getDevice().getSystemColor(SWT.COLOR_WHITE);
-		}
-		gc.setBackground(color);
-		int[] tmpPoints = new int[index];
-		System.arraycopy(points, 0, tmpPoints, 0, index);
-		Color tempBorder = new Color(gc.getDevice(), 182, 188, 204);
 		if ((state & SWT.HOT) != 0) {
-			gc.fillPolygon(tmpPoints);
-			gc.setForeground(unselectedHoverBorderColor == null ? tempBorder : unselectedHoverBorderColor);
-			gc.drawPolyline(tmpPoints);
-		} else {
-			gc.setForeground(unselectedTabOutlineColor == null ? tempBorder : unselectedTabOutlineColor);
-			if (active) {
-				gc.drawPolyline(tmpPoints);
+			int header = 0;
+			int width = bounds.width;
+			boolean onBottom = parent.getTabPosition() == SWT.BOTTOM;
+			int bottomY = onBottom ? bounds.y - header : bounds.y + bounds.height;
+
+			// Remember for use in header drawing
+			if (cornerSize == SQUARE_CORNER) {
+				Color color = hotUnselectedTabsColorBackground;
+				if (color == null) {
+					// Fallback: if color was not set, use white for highlighting
+					// hot tab.
+					color = gc.getDevice().getSystemColor(SWT.COLOR_WHITE);
+				}
+				gc.setBackground(color);
+
+				Rectangle rect = new Rectangle(bounds.x, bounds.y, bounds.width, bounds.height);
+				gc.fillRectangle(rect);
 			} else {
-				gc.drawLine(inactive[0], inactive[1], inactive[2], inactive[3]);
-				gc.drawLine(inactive[4], inactive[5], inactive[6], inactive[7]);
+				int[] points = new int[1024];
+				int[] inactive = new int[8];
+				int index = 0, inactive_index = 0;
+				int radius = cornerSize / 2;
+				int circX = bounds.x + radius;
+				int circY = onBottom ? bounds.y + bounds.height + 1 - header - radius : bounds.y - 1 + radius;
+
+				int leftIndex = circX;
+				if (itemIndex == 0) {
+					if (parent.getSelectionIndex() != 0)
+						leftIndex -= 1;
+					points[index++] = leftIndex - radius;
+					points[index++] = bottomY;
+				} else {
+					points[index++] = bounds.x;
+					points[index++] = bottomY;
+				}
+
+				if (!active) {
+					System.arraycopy(points, 0, inactive, 0, index);
+					inactive_index += 2;
+				}
+
+				int rightIndex = circX - 1;
+
+				int[] ltt = drawCircle(leftIndex, circY, radius, CirclePart.left(onBottom));
+				if (!onBottom) {
+					mirrorCirclePoints(ltt);
+				}
+				System.arraycopy(ltt, 0, points, index, ltt.length);
+				index += ltt.length;
+
+				if (!active) {
+					System.arraycopy(ltt, 0, inactive, inactive_index, 2);
+					inactive_index += 2;
+				}
+
+				int[] rt = drawCircle(rightIndex + width - (radius * 2), circY, radius, CirclePart.right(onBottom));
+				if (!onBottom) {
+					mirrorCirclePoints(rt);
+				}
+				System.arraycopy(rt, 0, points, index, rt.length);
+				index += rt.length;
+
+				if (!active) {
+					System.arraycopy(rt, rt.length - 4, inactive, inactive_index, 2);
+					inactive[inactive_index] -= 1;
+					inactive_index += 2;
+				}
+
+				points[index++] = bounds.width + rightIndex - radius;
+				points[index++] = bottomY;
+
+				if (!active) {
+					System.arraycopy(points, index - 2, inactive, inactive_index, 2);
+					inactive[inactive_index] -= 1;
+					inactive_index += 2;
+				}
+				gc.setClipping(points[0], onBottom ? bounds.y - header : bounds.y,
+						parent.getSize().x + INNER_KEYLINE_WIDTH + OUTER_KEYLINE_WIDTH, bounds.y + bounds.height);
+
+				Color color = hotUnselectedTabsColorBackground;
+				if (color == null) {
+					// Fallback: if color was not set, use white for highlighting
+					// hot tab.
+					color = gc.getDevice().getSystemColor(SWT.COLOR_WHITE);
+				}
+				gc.setBackground(color);
+
+				int[] tmpPoints = new int[index];
+				System.arraycopy(points, 0, tmpPoints, 0, index);
+				gc.fillPolygon(tmpPoints);
+
+				if (tabOutlineColor == null)
+					tabOutlineColor = gc.getDevice().getSystemColor(SWT.COLOR_BLACK);
+				gc.setForeground(tabOutlineColor);
+
+				if (active) {
+					gc.drawPolyline(tmpPoints);
+				} else {
+					gc.drawLine(inactive[0], inactive[1], inactive[2], inactive[3]);
+					gc.drawLine(inactive[4], inactive[5], inactive[6], inactive[7]);
+				}
+				gc.setClipping((Rectangle) null);
 			}
+
+			// gc.setForeground(outerKeyline);
+			// gc.drawPolyline(shape);
 		}
-		tempBorder.dispose();
-
-		Rectangle rect = null;
-		gc.setClipping(rect);
-
-		// gc.setForeground(outerKeyline);
-		// gc.drawPolyline(shape);
 	}
 
-	static int[] drawCircle(int xC, int yC, int r, int circlePart) {
+	private static void mirrorCirclePoints(int[] circle) {
+		for (int i = 0; i < circle.length / 2; i += 2) {
+			int tmp = circle[i];
+			circle[i] = circle[circle.length - i - 2];
+			circle[circle.length - i - 2] = tmp;
+			tmp = circle[i + 1];
+			circle[i + 1] = circle[circle.length - i - 1];
+			circle[circle.length - i - 1] = tmp;
+		}
+	}
+
+	static int[] drawCircle(int xC, int yC, int r, CirclePart circlePart) {
 		int x = 0, y = r, u = 1, v = 2 * r - 1, e = 0;
 		int[] points = new int[1024];
 		int[] pointsMirror = new int[1024];
 		int loop = 0;
 		int loopMirror = 0;
 		while (x < y) {
-			if (circlePart == RIGHT_BOTTOM) {
-				points[loop++] = xC + x;
-				points[loop++] = yC + y;
-			}
-			if (circlePart == RIGHT_TOP) {
-				points[loop++] = xC + y;
-				points[loop++] = yC - x;
-			}
-			if (circlePart == LEFT_TOP) {
-				points[loop++] = xC - x;
-				points[loop++] = yC - y;
-			}
-			if (circlePart == LEFT_BOTTOM) {
-				points[loop++] = xC - y;
-				points[loop++] = yC + x;
-			}
+			loop = drawCirclePoint(loop, xC, yC, points, x, y, circlePart);
 			x++;
 			e += u;
 			u += 2;
@@ -774,25 +742,9 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 				e -= v;
 				v -= 2;
 			}
-			if (x > y) {
+			if (x > y)
 				break;
-			}
-			if (circlePart == RIGHT_BOTTOM) {
-				pointsMirror[loopMirror++] = xC + y;
-				pointsMirror[loopMirror++] = yC + x;
-			}
-			if (circlePart == RIGHT_TOP) {
-				pointsMirror[loopMirror++] = xC + x;
-				pointsMirror[loopMirror++] = yC - y;
-			}
-			if (circlePart == LEFT_TOP) {
-				pointsMirror[loopMirror++] = xC - y;
-				pointsMirror[loopMirror++] = yC - x;
-			}
-			if (circlePart == LEFT_BOTTOM) {
-				pointsMirror[loopMirror++] = xC - x;
-				pointsMirror[loopMirror++] = yC + y;
-			}
+			loopMirror = drawCirclePoint(loopMirror, xC, yC, pointsMirror, y, x, circlePart);
 			// grow?
 			if ((loop + 1) > points.length) {
 				int length = points.length * 2;
@@ -813,6 +765,28 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			finalArray[j + 1] = tempY;
 		}
 		return finalArray;
+	}
+
+	private static int drawCirclePoint(int loop, int xC, int yC, int[] points, int x, int y, CirclePart circlePart) {
+		switch (circlePart) {
+		case RIGHT_BOTTOM:
+			points[loop++] = xC + x;
+			points[loop++] = yC + y;
+			break;
+		case RIGHT_TOP:
+			points[loop++] = xC + y;
+			points[loop++] = yC - x;
+			break;
+		case LEFT_TOP:
+			points[loop++] = xC - x;
+			points[loop++] = yC - y;
+			break;
+		case LEFT_BOTTOM:
+			points[loop++] = xC - y;
+			points[loop++] = yC + x;
+			break;
+		}
+		return loop;
 	}
 
 	static RGB blend(RGB c1, RGB c2, int ratio) {
@@ -884,12 +858,10 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 				for (int k = -kernelMid; k <= kernelMid; k++) {
 					float val = kernel[k + kernelMid];
 					int xcoord = x + k;
-					if (xcoord < 0) {
+					if (xcoord < 0)
 						xcoord = 0;
-					}
-					if (xcoord >= width) {
+					if (xcoord >= width)
 						xcoord = width - 1;
-					}
 					int pixel = inPixels[currentLine + xcoord];
 					// float alp = ((pixel >> 24) & 0xff);
 					a += val * ((pixel >> 24) & 0xff);
@@ -909,12 +881,10 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	}
 
 	private int clamp(int value) {
-		if (value > 255) {
+		if (value > 255)
 			return 255;
-		}
-		if (value < 0) {
+		if (value < 0)
 			return 0;
-		}
 		return value;
 	}
 
@@ -1010,12 +980,6 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	}
 
 	@Override
-	public void setUnselectedTabOutline(Color color) {
-		this.unselectedTabOutlineColor = color;
-		parent.redraw();
-	}
-
-	@Override
 	public void setInnerKeyline(Color color) {
 		this.innerKeylineColor = color;
 		parent.redraw();
@@ -1050,8 +1014,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		Rectangle partHeaderBounds = computeTrim(PART_HEADER, state, bounds.x, bounds.y, bounds.width, bounds.height);
 
 		drawUnselectedTabBackground(gc, partHeaderBounds, state, vertical, parent.getBackground());
-		drawTabBackground(gc, partHeaderBounds, state, vertical, parent.getBackground());
-		drawChildrenBackground(partHeaderBounds);
+		drawSelectedTabBackground(gc, partHeaderBounds, state, vertical, parent.getBackground());
 	}
 
 	private void drawUnselectedTabBackground(GC gc, Rectangle partHeaderBounds, int state, boolean vertical,
@@ -1068,21 +1031,20 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			unselectedTabsPercents = new int[] { 100 };
 		}
 
-		rendererWrapper.drawBackground(gc, partHeaderBounds.x, partHeaderBounds.y - 1, partHeaderBounds.width,
-				partHeaderBounds.height,
+		drawBackground(gc, partHeaderBounds.x, partHeaderBounds.y - 1, partHeaderBounds.width, partHeaderBounds.height,
 				defaultBackground, unselectedTabsColors, unselectedTabsPercents, vertical);
 	}
 
-	private void drawTabBackground(GC gc, Rectangle partHeaderBounds, int state, boolean vertical,
+	private void drawSelectedTabBackground(GC gc, Rectangle partHeaderBounds, int state, boolean vertical,
 			Color defaultBackground) {
-		boolean selected = (state & SWT.SELECTED) != 0;
 		Color[] colors = selectedTabFillColors;
 		int[] percents = selectedTabFillPercents;
-		if (!selected) {
-			colors = unselectedTabsColors;
-			percents = unselectedTabsPercents;
+
+		if (colors != null && colors.length == 2) {
+			colors = new Color[] { colors[1], colors[1] };
 		}
 		if (colors == null) {
+			boolean selected = (state & SWT.SELECTED) != 0;
 			colors = selected ? parentWrapper.getSelectionGradientColors() : parentWrapper.getGradientColors();
 			percents = selected ? parentWrapper.getSelectionGradientPercents() : parentWrapper.getGradientPercents();
 		}
@@ -1090,83 +1052,102 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			colors = new Color[] { gc.getDevice().getSystemColor(SWT.COLOR_WHITE) };
 			percents = new int[] { 100 };
 		}
+
+		boolean onBottom = parent.getTabPosition() == SWT.BOTTOM;
+		int borderTop = onBottom ? INNER_KEYLINE_WIDTH + OUTER_KEYLINE_WIDTH : TOP_KEYLINE_WIDTH + OUTER_KEYLINE_WIDTH;
+		Rectangle parentBounds = parent.getBounds();
+		int y = (onBottom) ? 0 : partHeaderBounds.y + partHeaderBounds.height - 1;
+		int height = (onBottom) ? parentBounds.height - partHeaderBounds.height + 2 * paddingTop + 2 * borderTop
+				: parentBounds.height - partHeaderBounds.height;
+
+		drawBackground(gc, partHeaderBounds.x, y, partHeaderBounds.width, height, defaultBackground, colors, percents,
+				vertical);
+	}
+
+	/*
+	 * Copied the relevant parts from the package private
+	 * org.eclipse.swt.custom.CTabFolderRenderer.drawBackground(GC, int[], int, int,
+	 * int, int, Color, Image, Color[], int[], boolean) method.
+	 */
+	private void drawBackground(GC gc, int x, int y, int width, int height, Color defaultBackground, Color[] colors,
+			int[] percents, boolean vertical) {
 		if (colors != null) {
-			if (colors.length == 2) {
-				colors = new Color[] { colors[0], colors[1] };
+			// draw gradient
+			if (colors.length == 1) {
+				Color background = colors[0] != null ? colors[0] : defaultBackground;
+				gc.setBackground(background);
+				gc.fillRectangle(x, y, width, height);
 			} else {
-				colors = new Color[] { colors[0], colors[0] };
-			}
-		}
-
-		rendererWrapper.drawBackground(gc, partHeaderBounds.x, partHeaderBounds.height, partHeaderBounds.width,
-				parent.getBounds().height, defaultBackground, colors, percents, vertical);
-		Control topRight = parent.getTopRight();
-		if (topRight != null) {
-			if (topRight.getBounds().y > 5) {
-				topRight.setBackground(wrappedTabFolderColor == null ? colors[1] : wrappedTabFolderColor);
-
-				if (fillToolbarArea) {
-					colors = new Color[] { wrappedTabFolderColor == null ? colors[1] : wrappedTabFolderColor };
-					percents = new int[] { 100 };
-					rendererWrapper.drawBackground(gc, partHeaderBounds.x, partHeaderBounds.height,
-							partHeaderBounds.width, topRight.getBounds().height, defaultBackground, colors, percents,
-							vertical);
+				if (vertical) {
+					if ((parent.getStyle() & SWT.BOTTOM) != 0) {
+						int pos = 0;
+						if (percents[percents.length - 1] < 100) {
+							pos = (100 - percents[percents.length - 1]) * height / 100;
+							gc.setBackground(defaultBackground);
+							gc.fillRectangle(x, y, width, pos);
+						}
+						Color lastColor = colors[colors.length - 1];
+						if (lastColor == null)
+							lastColor = defaultBackground;
+						for (int i = percents.length - 1; i >= 0; i--) {
+							gc.setForeground(lastColor);
+							lastColor = colors[i];
+							if (lastColor == null)
+								lastColor = defaultBackground;
+							gc.setBackground(lastColor);
+							int percentage = i > 0 ? percents[i] - percents[i - 1] : percents[i];
+							int gradientHeight = percentage * height / 100;
+							gc.fillGradientRectangle(x, y + pos, width, gradientHeight, true);
+							pos += gradientHeight;
+						}
+					} else {
+						Color lastColor = colors[0];
+						if (lastColor == null)
+							lastColor = defaultBackground;
+						int pos = 0;
+						for (int i = 0; i < percents.length; i++) {
+							gc.setForeground(lastColor);
+							lastColor = colors[i + 1];
+							if (lastColor == null)
+								lastColor = defaultBackground;
+							gc.setBackground(lastColor);
+							int percentage = i > 0 ? percents[i] - percents[i - 1] : percents[i];
+							int gradientHeight = percentage * height / 100;
+							gc.fillGradientRectangle(x, y + pos, width, gradientHeight, true);
+							pos += gradientHeight;
+						}
+						if (pos < height) {
+							gc.setBackground(defaultBackground);
+							gc.fillRectangle(x, pos, width, height - pos + 1);
+						}
+					}
+				} else { // horizontal gradient
+					y = 0;
+					height = parent.getSize().y;
+					Color lastColor = colors[0];
+					if (lastColor == null)
+						lastColor = defaultBackground;
+					int pos = 0;
+					for (int i = 0; i < percents.length; ++i) {
+						gc.setForeground(lastColor);
+						lastColor = colors[i + 1];
+						if (lastColor == null)
+							lastColor = defaultBackground;
+						gc.setBackground(lastColor);
+						int gradientWidth = (percents[i] * width / 100) - pos;
+						gc.fillGradientRectangle(x + pos, y, gradientWidth, height, false);
+						pos += gradientWidth;
+					}
+					if (pos < width) {
+						gc.setBackground(defaultBackground);
+						gc.fillRectangle(x + pos, y, width - pos, height);
+					}
 				}
-			} else {
-				topRight.setBackground(null);
 			}
-		}
-	}
-
-	// Workaround for the bug 433276. Remove it when the bug gets fixed
-	private void drawChildrenBackground(Rectangle partHeaderBounds) {
-		// for (Control control : parent.getChildren()) {
-		// if (!hasBackgroundOverriddenByCSS(control)
-		// && containsToolbar(control)) {
-		// drawChildBackground((Composite) control, partHeaderBounds);
-		// }
-		// }
-	}
-
-	private boolean containsToolbar(Control control) {
-		if (control.getData(CONTAINS_TOOLBAR) != null) {
-			return true;
-		}
-
-		if (control instanceof Composite) {
-			for (Control child : ((Composite) control).getChildren()) {
-				if (child instanceof ToolBar) {
-					control.setData(CONTAINS_TOOLBAR, true);
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	private Color getGradientLineTop(GC gc) {
-		RGB blendColor = gc.getDevice().getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW).getRGB();
-		RGB topGradient = blend(blendColor, tabOutlineColor.getRGB(), 40);
-		Color gradientLineTop = new Color(gc.getDevice(), topGradient);
-		return gradientLineTop;
-	}
-
-	private static class CTabFolderRendererWrapper extends ReflectionSupport<CTabFolderRenderer> {
-		private Method drawBackgroundMethod;
-
-		public CTabFolderRendererWrapper(CTabFolderRenderer instance) {
-			super(instance);
-		}
-
-		public void drawBackground(GC gc, int x, int y, int width, int height, Color defaultBackground, Color[] colors,
-				int[] percents, boolean vertical) {
-			if (drawBackgroundMethod == null) {
-				drawBackgroundMethod = getMethod("drawBackground", //$NON-NLS-1$
-						new Class<?>[] { GC.class, int[].class, int.class, int.class, int.class, int.class, Color.class,
-								Image.class, Color[].class, int[].class, boolean.class });
-			}
-			executeMethod(drawBackgroundMethod, new Object[] { gc, null, x, y, width, height, defaultBackground, null,
-					colors, percents, vertical });
+		} else // draw a solid background using default background in shape
+		if ((parent.getStyle() & SWT.NO_BACKGROUND) != 0 || !defaultBackground.equals(parent.getBackground())) {
+			gc.setBackground(defaultBackground);
+			gc.fillRectangle(x, y, width, height);
 		}
 	}
 
@@ -1233,7 +1214,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	}
 
 	private static class ReflectionSupport<T> {
-		private final T instance;
+		private T instance;
 
 		public ReflectionSupport(T instance) {
 			this.instance = instance;
@@ -1260,34 +1241,6 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			while (!cls.equals(Object.class)) {
 				try {
 					return cls.getDeclaredField(name);
-				} catch (Exception exc) {
-					cls = cls.getSuperclass();
-				}
-			}
-			return null;
-		}
-
-		protected Object executeMethod(Method method, Object... params) {
-			Object value = null;
-			if (method != null) {
-				boolean accessible = method.isAccessible();
-				try {
-					method.setAccessible(true);
-					value = method.invoke(instance, params);
-				} catch (Exception exc) {
-					// do nothing
-				} finally {
-					method.setAccessible(accessible);
-				}
-			}
-			return value;
-		}
-
-		protected Method getMethod(String name, Class<?>... params) {
-			Class<?> cls = instance.getClass();
-			while (!cls.equals(Object.class)) {
-				try {
-					return cls.getDeclaredMethod(name, params);
 				} catch (Exception exc) {
 					cls = cls.getSuperclass();
 				}


### PR DESCRIPTION
Revert custom styling, replace CTabRendering, CSSPropertyUnselectedTabsSWTHandler with Eclipse's source. Previous PR https://github.com/Halliburton-Landmark/eclipse.platform.ui/pull/29 provide some changes that are not compatible with eclipse 4-27 platform