### PR TITLE
Bug1187783 QuickAccess Linux exceptions

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessDialog.java
@@ -208,10 +208,10 @@ public class QuickAccessDialog extends PopupDialog {
 
 						/*
 						 * Execute after the dialog has been fully closed/disposed and the correct
-						 * EclipseContext is in place.
+						 * EclipseContext and active shell are in place.
 						 */
 						final QuickAccessElement element = (QuickAccessElement) selectedElement;
-						window.getShell().getDisplay().asyncExec(element::execute);
+						display.asyncExec(() -> display.asyncExec(element::execute));
 					}
 				}
 			};

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.128.0.lgc20230509-1200
+Bundle-Version: 3.128.0.lgc20240229-1200
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
We made changes to WorkbenchSourceProvider several years ago to fix a bug where workbench.getActiveWorkbenchWindow returned the incorrect value due to the wrong MWindow as the MApplication selectedElement.  The change included asynchronous update of ISources values so that it accesses the correct active workbench window.

https://github.com/Halliburton-Landmark/eclipse.platform.ui/commit/f7c2fc6161bae84626861eecf3d820a7825d7697#diff-4d659c991049dde1b14866606d80b1d0a297a4334a7e22ec1b5e23669525714a

WorkbenchSourceProvider must update only after ShellActivationListener and WBWRenderer have executed.
The QuickAccessDialog command must execute only after WorkbenchSourceProvider has updated.

ShellActivationListener is a Display filter on SWT.Activate events.
It activates the context of the Shell.  This may be the shell and context of a MWindow.

WBWRenderer is a shell SWT.Activate listener.
It sets the MApplication selectedElement to the shell MWindow.

Display filters always execute before ordinary listeners.
In this case the MWindow context is activated before the MApplication selectedElement is set to the MWIndow.

With this prior necessary change we must delay the QuickAccess Command invocation until after the WorkbenchSourceProvider sets the ISources values. Among the values set is the active shell that HandlerUtil.getActiveShell accesses.

Without the double asynchronous invocation, HandlerUtil.getActiveShell accesses the disposed shell of the QuickAccessDialog.  Essentially, there is a competition to be at the end of the event queue.

The change fixes the Linux error and continues to work on Windows.