### PR TITLE
Avoid duplicate quick access entry https://github.com/eclipse-platform/eclipse.platform.ui/issues/152

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -540,6 +540,14 @@ public abstract class QuickAccessContents {
 					QuickAccessEntry.MATCH_PERFECT)));
 		}
 		res.addAll(entriesPerProvider.values());
+
+		// if one category provides the same single entry like "previous", we can avoid
+		// showing the duplicate second list
+		if (res.size() >= 2 && res.get(0).size() == 1 && res.get(1).size() == 1
+				&& (res.get(0).get(0).element.equals(res.get(1).get(0).element))) {
+			res.remove(1);
+		}
+
 		return (List<QuickAccessEntry>[]) res.toArray(new List<?>[res.size()]);
 	}
 

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.131.0.lgc202405729-1900
+Bundle-Version: 3.131.0.lgc20240729-1900
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.131.0.lgc20240523-1900
+Bundle-Version: 3.131.0.lgc202405729-1900
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName


### PR DESCRIPTION
This PR to pick-up Eclipse proposed fix for https://github.com/eclipse-platform/eclipse.platform.ui/issues/152 <p>
https://github.com/eclipse-platform/eclipse.platform.ui/commit/344f1d1dd0ba7a80a7cb1ab3fce68d09a761bfc2

This PR is related to ADO 1200420: Quick Access shows Previous Choices option twice