### PR TITLE
Hide X (close) button in Progress Monitor Dialog

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.32.0.lgc20240815-1600
+Bundle-Version: 3.32.0.lgc20250430-1900
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/ProgressMonitorDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/ProgressMonitorDialog.java
@@ -300,7 +300,7 @@ public class ProgressMonitorDialog extends IconAndMessageDialog implements
 		// no close button on the shell style
 		if (isResizable()) {
 			setShellStyle(getDefaultOrientation() | SWT.BORDER | SWT.TITLE
-					| SWT.APPLICATION_MODAL | SWT.RESIZE | SWT.MAX);
+					| SWT.APPLICATION_MODAL | SWT.RESIZE);
 		} else {
 			setShellStyle(getDefaultOrientation() | SWT.BORDER | SWT.TITLE
 					| SWT.APPLICATION_MODAL);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressMonitorFocusJobDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressMonitorFocusJobDialog.java
@@ -58,7 +58,7 @@ public class ProgressMonitorFocusJobDialog extends ProgressMonitorJobsDialog {
 	 */
 	public ProgressMonitorFocusJobDialog(Shell parentShell) {
 		super(parentShell == null ? ProgressManagerUtil.getNonModalShell() : parentShell);
-		setShellStyle(getDefaultOrientation() | SWT.BORDER | SWT.TITLE | SWT.RESIZE | SWT.MAX | SWT.MODELESS);
+		setShellStyle(getDefaultOrientation() | SWT.BORDER | SWT.TITLE | SWT.RESIZE | SWT.MODELESS);
 		setCancelable(true);
 		enableDetailsButton = true;
 	}

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.131.0.lgc20240729-1900
+Bundle-Version: 3.131.0.lgc20250430-1900
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName


### PR DESCRIPTION
This button does nothing if a job is still running (see https://github.com/eclipse-platform/eclipse.platform.ui/blob/R4_30_maintenance/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/ProgressMonitorDialog.java#L345). This behavior is confusing to the user.


Note, On Windows SWT.MAX adds 3 buttons: Minimize, Maximize, and Close. On Linux (GTK) - only one: Maximize.
Neither of these buttons are useful on both platforms.

Preview of a dialog with this patch:
![image](https://github.com/user-attachments/assets/61eff61e-ba42-477a-8d09-027e16072bee)
