### PR TITLE
ADO1507392 revert MenuManager Commit 26d3780

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.32.0.lgc20250430-1900
+Bundle-Version: 3.32.0.lgc20250725-1400
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/MenuManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/MenuManager.java
@@ -654,11 +654,7 @@ public class MenuManager extends ContributionManager implements IMenuManager {
 
 	@Override
 	public void update() {
-//		This used to disable the menu item if this menu manager was part of a
-//		parent menu and the sub menu is empty. This is not necessary anymore,
-//		because in that case the menu is completely invisible.
-//		See bugs #34969, #47098, #552413, #552659.
-//		See isVisible().
+		updateMenuItem();
 	}
 
 	/**
@@ -836,18 +832,21 @@ public class MenuManager extends ContributionManager implements IMenuManager {
 
 				setDirty(false);
 			}
-		} else // I am not dirty. Check if I must recursivly walk down the hierarchy.
-		if (recursive) {
-			IContributionItem[] items = getItems();
-			for (IContributionItem ci : items) {
-				if (ci instanceof IMenuManager) {
-					IMenuManager mm = (IMenuManager) ci;
-					if (isChildVisible(mm)) {
-						mm.updateAll(force);
+		} else {
+			// I am not dirty. Check if I must recursivly walk down the hierarchy.
+			if (recursive) {
+				IContributionItem[] items = getItems();
+				for (IContributionItem ci : items) {
+					if (ci instanceof IMenuManager) {
+						IMenuManager mm = (IMenuManager) ci;
+						if (isChildVisible(mm)) {
+							mm.updateAll(force);
+						}
 					}
 				}
 			}
 		}
+		updateMenuItem();
 	}
 
 	@Override
@@ -917,6 +916,41 @@ public class MenuManager extends ContributionManager implements IMenuManager {
 	@Override
 	public void updateAll(boolean force) {
 		update(force, true);
+	}
+
+	/**
+	 * Updates the menu item for this sub menu. The menu item is disabled if this
+	 * sub menu is empty. Does nothing if this menu is not a submenu.
+	 */
+	private void updateMenuItem() {
+		/*
+		 * Commented out until proper solution to enablement of menu item for a sub-menu
+		 * is found. See bug 30833 for more details.
+		 *
+		 * if (menuItem != null && !menuItem.isDisposed() && menuExist()) {
+		 * IContributionItem items[] = getItems(); boolean enabled = false; for (int i =
+		 * 0; i < items.length; i++) { IContributionItem item = items[i]; enabled =
+		 * item.isEnabled(); if(enabled) break; } // Workaround for 1GDDCN2: SWT:Linux -
+		 * MenuItem.setEnabled() always causes a redraw if (menuItem.getEnabled() !=
+		 * enabled) menuItem.setEnabled(enabled); }
+		 */
+		// Partial fix for bug #34969 - diable the menu item if no
+		// items in sub-menu (for context menus).
+		if (menuItem != null && !menuItem.isDisposed() && menuExist()) {
+			boolean enabled = removeAllWhenShown || menu.getItemCount() > 0;
+			// Workaround for 1GDDCN2: SWT:Linux - MenuItem.setEnabled() always causes a
+			// redraw
+			if (menuItem.getEnabled() != enabled) {
+				// We only do this for context menus (for bug #34969)
+				Menu topMenu = menu;
+				while (topMenu.getParentMenu() != null) {
+					topMenu = topMenu.getParentMenu();
+				}
+				if ((topMenu.getStyle() & SWT.BAR) == 0) {
+					menuItem.setEnabled(enabled);
+				}
+			}
+		}
 	}
 
 	private boolean isChildVisible(IContributionItem item) {


### PR DESCRIPTION

Workflow

a.) Launch the application.
b.) Select a new session and set the session parametres, Geoscience perspective, Cube, Map, Section, Well Correlation
     editors.
c.) Click on the Add Data window and add some frameworks to the session.
d.) In the Inventory tree, click MB3 on the main Frameworks node and select Configure Labels.

Result : Nothing happens.

              Although there is an arrow seen in front of the Configure Labels option, but it does not expand. Nor is it seen
              disabled as in DSG10ep5.4.04 and in the master build before_eclipse_jdk_merge, i.e., 2502070602.1701


Reverting MenuManager Commit 26d3780 changes restores the original behavior.
The reverted code was tested on various menus in DSG, Inventory Tree. Editor MB3, and Main Menu, with no ill-effects observed.

https://github.com/Halliburton-Landmark/eclipse.platform.ui/commit/26d37803217bce02868dcc04a75877221d4e6a5f#diff-e6c978cbb59739369a0fd5138c2c481854f43df4e23dc5e19cb788911db3a36cL657 

Bug 552659 - MenuManager contributed via menuContribution is disabled

MenuManager.updateMenuItem() is obsolete since bug 47098. Now, in case there are no visible children, the whole sub menu is invisible. There is no need anymore to change the enabled state of a sub menu item, as the constellation "sub menu item visible but disabled" cannot occur anymore.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=552659 


 
