### PR TITLE
Fix icon size for scales different from integer values

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.32.0.lgc20250725-1400
+Bundle-Version: 3.32.0.lgc20260102-1400
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
@@ -70,7 +70,7 @@ public class SvgImageDescriptor extends ImageDescriptor {
 
     @Override
     public ImageData getImageData(int zoom) {
-		int scale = zoom / 100;
+		float scale = zoom / 100f;
 		try {
 			byte[] imageBytes = SVGHelper.loadSvg(url, renderWidth * scale, renderHeight * scale);
 			return new ImageData(new ByteArrayInputStream(imageBytes));
@@ -125,6 +125,7 @@ public class SvgImageDescriptor extends ImageDescriptor {
 
 			try {
 				new URL(svgUrlSpec).openConnection().connect();
+				System.err.println(urlSpec);
 				urlSpec = svgUrlSpec;
 			} catch (IOException e) {
 				if (USE_OLD_SVG_IMAGES) {

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/SvgImageDescriptor.java
@@ -125,7 +125,6 @@ public class SvgImageDescriptor extends ImageDescriptor {
 
 			try {
 				new URL(svgUrlSpec).openConnection().connect();
-				System.err.println(urlSpec);
 				urlSpec = svgUrlSpec;
 			} catch (IOException e) {
 				if (USE_OLD_SVG_IMAGES) {


### PR DESCRIPTION
Fix icon size for scales different from integer values.
Current approach works fine for scales 100, 200, 300, and it supposed to be used with VM arg -Dswt.autoScale=integer.

In case of -Dswt.autoScale=quarter or -Dswt.autoScale=VALUE it provide incorrect ImageData size